### PR TITLE
Add support for TLS certification revocation list (CRL) files

### DIFF
--- a/data/test/mysql_ldap_auth_config.json
+++ b/data/test/mysql_ldap_auth_config.json
@@ -3,6 +3,7 @@
 		"LdapCert": "path/to/ldap-client-cert.pem",
 		"LdapKey": "path/to/ldap-client-key.pem",
 		"LdapCA": "path/to/ldap-client-ca.pem",
+		"LdapCRL": "path/to/ldap-client-crl.pem",
 		"User": "uid=vitessROuser,ou=users,ou=people,dc=example,dc=com",
 		"Password": "sUpErSeCuRe1",
 		"GroupQuery": "ou=groups,ou=people,dc=example,dc=com",

--- a/go/mysql/auth_server_clientcert_test.go
+++ b/go/mysql/auth_server_clientcert_test.go
@@ -55,12 +55,14 @@ func TestValidCert(t *testing.T) {
 	tlstest.CreateCA(root)
 	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
 	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", clientCertUsername)
+	tlstest.CreateCRL(root, tlstest.CA)
 
 	// Create the server with TLS config.
 	serverConfig, err := vttls.ServerConfig(
 		path.Join(root, "server-cert.pem"),
 		path.Join(root, "server-key.pem"),
 		path.Join(root, "ca-cert.pem"),
+		path.Join(root, "ca-crl.pem"),
 		"",
 		tls.VersionTLS12)
 	if err != nil {
@@ -137,12 +139,14 @@ func TestNoCert(t *testing.T) {
 	defer os.RemoveAll(root)
 	tlstest.CreateCA(root)
 	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
+	tlstest.CreateCRL(root, tlstest.CA)
 
 	// Create the server with TLS config.
 	serverConfig, err := vttls.ServerConfig(
 		path.Join(root, "server-cert.pem"),
 		path.Join(root, "server-key.pem"),
 		path.Join(root, "ca-cert.pem"),
+		path.Join(root, "ca-crl.pem"),
 		"",
 		tls.VersionTLS12)
 	if err != nil {

--- a/go/mysql/client.go
+++ b/go/mysql/client.go
@@ -282,7 +282,7 @@ func (c *Conn) clientHandshake(characterSet uint8, params *ConnParams) error {
 		}
 
 		// Build the TLS config.
-		clientConfig, err := vttls.ClientConfig(params.EffectiveSslMode(), params.SslCert, params.SslKey, params.SslCa, serverName, tlsVersion)
+		clientConfig, err := vttls.ClientConfig(params.EffectiveSslMode(), params.SslCert, params.SslKey, params.SslCa, params.SslCrl, serverName, tlsVersion)
 		if err != nil {
 			return NewSQLError(CRSSLConnectionError, SSUnknownSQLState, "error loading client cert and ca: %v", err)
 		}

--- a/go/mysql/conn_params.go
+++ b/go/mysql/conn_params.go
@@ -39,6 +39,7 @@ type ConnParams struct {
 	SslCa            string        `json:"ssl_ca"`
 	SslCaPath        string        `json:"ssl_ca_path"`
 	SslCert          string        `json:"ssl_cert"`
+	SslCrl           string        `json:"ssl_crl"`
 	SslKey           string        `json:"ssl_key"`
 	TLSMinVersion    string        `json:"tls_min_version"`
 	ServerName       string        `json:"server_name"`

--- a/go/mysql/handshake_test.go
+++ b/go/mysql/handshake_test.go
@@ -127,6 +127,7 @@ func TestSSLConnection(t *testing.T) {
 		path.Join(root, "server-key.pem"),
 		path.Join(root, "ca-cert.pem"),
 		"",
+		"",
 		tls.VersionTLS12)
 	if err != nil {
 		t.Fatalf("TLSServerConfig failed: %v", err)

--- a/go/mysql/ldapauthserver/auth_server_ldap.go
+++ b/go/mysql/ldapauthserver/auth_server_ldap.go
@@ -215,6 +215,7 @@ type ServerConfig struct {
 	LdapCert          string
 	LdapKey           string
 	LdapCA            string
+	LdapCRL           string
 	LdapTLSMinVersion string
 }
 
@@ -250,7 +251,7 @@ func (lci *ClientImpl) Connect(network string, config *ServerConfig) error {
 		return err
 	}
 
-	tlsConfig, err := vttls.ClientConfig(vttls.VerifyIdentity, config.LdapCert, config.LdapKey, config.LdapCA, serverName, tlsVersion)
+	tlsConfig, err := vttls.ClientConfig(vttls.VerifyIdentity, config.LdapCert, config.LdapKey, config.LdapCA, config.LdapCRL, serverName, tlsVersion)
 	if err != nil {
 		return err
 	}

--- a/go/mysql/mysql_fuzzer.go
+++ b/go/mysql/mysql_fuzzer.go
@@ -358,6 +358,7 @@ func FuzzTLSServer(data []byte) int {
 		path.Join(root, "server-key.pem"),
 		path.Join(root, "ca-cert.pem"),
 		"",
+		"",
 		tls.VersionTLS12)
 	if err != nil {
 		return -1

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -834,6 +834,7 @@ func TestTLSServer(t *testing.T) {
 		path.Join(root, "server-key.pem"),
 		path.Join(root, "ca-cert.pem"),
 		"",
+		"",
 		tls.VersionTLS12)
 	require.NoError(t, err)
 	l.TLSConfig.Store(serverConfig)
@@ -925,12 +926,16 @@ func TestTLSRequired(t *testing.T) {
 	defer os.RemoveAll(root)
 	tlstest.CreateCA(root)
 	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
+	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")
+	tlstest.CreateSignedCert(root, tlstest.CA, "03", "revoked-client", "Revoked Client Cert")
+	tlstest.RevokeCertAndRegenerateCRL(root, tlstest.CA, "revoked-client")
 
 	// Create the server with TLS config.
 	serverConfig, err := vttls.ServerConfig(
 		path.Join(root, "server-cert.pem"),
 		path.Join(root, "server-key.pem"),
 		path.Join(root, "ca-cert.pem"),
+		path.Join(root, "ca-crl.pem"),
 		"",
 		tls.VersionTLS12)
 	require.NoError(t, err)
@@ -967,7 +972,6 @@ func TestTLSRequired(t *testing.T) {
 	}
 
 	// setup conn params with TLS
-	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")
 	params.SslMode = vttls.VerifyIdentity
 	params.SslCa = path.Join(root, "ca-cert.pem")
 	params.SslCert = path.Join(root, "client-cert.pem")
@@ -975,6 +979,16 @@ func TestTLSRequired(t *testing.T) {
 
 	conn, err = Connect(context.Background(), params)
 	require.NoError(t, err)
+	if conn != nil {
+		conn.Close()
+	}
+
+	// setup conn params with TLS, but with a revoked client certificate
+	params.SslCert = path.Join(root, "revoked-client-cert.pem")
+	params.SslKey = path.Join(root, "revoked-client-key.pem")
+	conn, err = Connect(context.Background(), params)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "remote error: tls: bad certificate")
 	if conn != nil {
 		conn.Close()
 	}
@@ -1013,6 +1027,7 @@ func TestCachingSha2PasswordAuthWithTLS(t *testing.T) {
 		path.Join(root, "server-cert.pem"),
 		path.Join(root, "server-key.pem"),
 		path.Join(root, "ca-cert.pem"),
+		"",
 		"",
 		tls.VersionTLS12)
 	if err != nil {

--- a/go/test/endtoend/encryption/encryptedtransport/encrypted_transport_test.go
+++ b/go/test/endtoend/encryption/encryptedtransport/encrypted_transport_test.go
@@ -374,7 +374,7 @@ func tabletConnExtraArgs(name string) []string {
 }
 
 func getVitessClient(addr string) (vtgateservicepb.VitessClient, error) {
-	opt, err := grpcclient.SecureDialOption(grpcCert, grpcKey, grpcCa, grpcName)
+	opt, err := grpcclient.SecureDialOption(grpcCert, grpcKey, grpcCa, "", grpcName)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/binlog/grpcbinlogplayer/player.go
+++ b/go/vt/binlog/grpcbinlogplayer/player.go
@@ -36,6 +36,7 @@ var (
 	cert = flag.String("binlog_player_grpc_cert", "", "the cert to use to connect")
 	key  = flag.String("binlog_player_grpc_key", "", "the key to use to connect")
 	ca   = flag.String("binlog_player_grpc_ca", "", "the server ca to use to validate servers when connecting")
+	crl  = flag.String("binlog_player_grpc_crl", "", "the server crl to use to validate server certificates when connecting")
 	name = flag.String("binlog_player_grpc_server_name", "", "the server name to use to validate server certificate")
 )
 
@@ -48,7 +49,7 @@ type client struct {
 func (client *client) Dial(tablet *topodatapb.Tablet) error {
 	addr := netutil.JoinHostPort(tablet.Hostname, tablet.PortMap["grpc"])
 	var err error
-	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
+	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *crl, *name)
 	if err != nil {
 		return err
 	}

--- a/go/vt/grpcclient/client.go
+++ b/go/vt/grpcclient/client.go
@@ -125,7 +125,7 @@ func interceptors() []grpc.DialOption {
 // SecureDialOption returns the gRPC dial option to use for the
 // given client connection. It is either using TLS, or Insecure if
 // nothing is set.
-func SecureDialOption(cert, key, ca, name string) (grpc.DialOption, error) {
+func SecureDialOption(cert, key, ca, crl, name string) (grpc.DialOption, error) {
 	// No security options set, just return.
 	if (cert == "" || key == "") && ca == "" {
 		return grpc.WithInsecure(), nil
@@ -133,7 +133,7 @@ func SecureDialOption(cert, key, ca, name string) (grpc.DialOption, error) {
 
 	// Load the config. At this point we know
 	// we want a strict config with verify identity.
-	config, err := vttls.ClientConfig(vttls.VerifyIdentity, cert, key, ca, name, tls.VersionTLS12)
+	config, err := vttls.ClientConfig(vttls.VerifyIdentity, cert, key, ca, crl, name, tls.VersionTLS12)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -67,6 +67,9 @@ var (
 	// GRPCCA is the CA to use if TLS is enabled
 	GRPCCA = flag.String("grpc_ca", "", "server CA to use for gRPC connections, requires TLS, and enforces client certificate check")
 
+	// GRPCCRL is the CRL (Certificate Revocation List) to use if TLS is enabled
+	GRPCCRL = flag.String("grpc_crl", "", "path to a certificate revocation list in PEM format, client certificates will be further verified against this file during TLS handshake")
+
 	GRPCEnableOptionalTLS = flag.Bool("grpc_enable_optional_tls", false, "enable optional TLS mode when a server accepts both TLS and plain-text connections on the same port")
 
 	// GRPCServerCA if specified will combine server cert and server CA
@@ -133,7 +136,7 @@ func createGRPCServer() {
 
 	var opts []grpc.ServerOption
 	if GRPCPort != nil && *GRPCCert != "" && *GRPCKey != "" {
-		config, err := vttls.ServerConfig(*GRPCCert, *GRPCKey, *GRPCCA, *GRPCServerCA, tls.VersionTLS12)
+		config, err := vttls.ServerConfig(*GRPCCert, *GRPCKey, *GRPCCA, *GRPCCRL, *GRPCServerCA, tls.VersionTLS12)
 		if err != nil {
 			log.Exitf("Failed to log gRPC cert/key/ca: %v", err)
 		}

--- a/go/vt/throttler/grpcthrottlerclient/grpcthrottlerclient.go
+++ b/go/vt/throttler/grpcthrottlerclient/grpcthrottlerclient.go
@@ -36,6 +36,7 @@ var (
 	cert = flag.String("throttler_client_grpc_cert", "", "the cert to use to connect")
 	key  = flag.String("throttler_client_grpc_key", "", "the key to use to connect")
 	ca   = flag.String("throttler_client_grpc_ca", "", "the server ca to use to validate servers when connecting")
+	crl  = flag.String("throttler_client_grpc_crl", "", "the server crl to use to validate server certificates when connecting")
 	name = flag.String("throttler_client_grpc_server_name", "", "the server name to use to validate server certificate")
 )
 
@@ -45,7 +46,7 @@ type client struct {
 }
 
 func factory(addr string) (throttlerclient.Client, error) {
-	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
+	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *crl, *name)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/tlstest/tlstest.go
+++ b/go/vt/tlstest/tlstest.go
@@ -32,7 +32,15 @@ const (
 	// CA is the name of the CA toplevel cert.
 	CA = "ca"
 
-	caConfig = `
+	caConfigTemplate = `
+[ ca ]
+default_ca = default_ca
+
+[ default_ca ]
+database = %s
+default_md = default
+default_crl_days = 30
+
 [ req ]
  default_bits           = 4096
  default_keyfile        = keyfile.pem
@@ -91,10 +99,28 @@ func openssl(argv ...string) {
 	cmd := exec.Command("openssl", argv...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		if len(output) > 0 {
+			log.Errorf("openssl %v returned:\n%v", argv, string(output))
+		}
 		log.Fatalf("openssl %v failed: %v", argv, err)
 	}
-	if len(output) > 0 {
-		log.Infof("openssl %v returned:\n%v", argv, string(output))
+}
+
+// createKeyDBAndCAConfig creates a key database and ca config file
+// for the passed in CA (possibly an intermediate CA)
+func createKeyDBAndCAConfig(root, parent string) {
+	databasePath := path.Join(root, parent+"-keys.db")
+	if _, err := os.Stat(databasePath); os.IsNotExist(err) {
+		if err := ioutil.WriteFile(databasePath, []byte{}, os.ModePerm); err != nil {
+			log.Fatalf("cannot write file %v: %v", databasePath, err)
+		}
+	}
+
+	config := path.Join(root, parent+"-ca.config")
+	if _, err := os.Stat(config); os.IsNotExist(err) {
+		if err := ioutil.WriteFile(config, []byte(fmt.Sprintf(caConfigTemplate, databasePath)), os.ModePerm); err != nil {
+			log.Fatalf("cannot write file %v: %v", config, err)
+		}
 	}
 }
 
@@ -105,12 +131,11 @@ func CreateCA(root string) {
 	log.Infof("Creating test root CA in %v", root)
 	key := path.Join(root, "ca-key.pem")
 	cert := path.Join(root, "ca-cert.pem")
+	config := path.Join(root, "ca-ca.config")
+	createKeyDBAndCAConfig(root, "ca")
+
 	openssl("genrsa", "-out", key)
 
-	config := path.Join(root, "ca.config")
-	if err := ioutil.WriteFile(config, []byte(caConfig), os.ModePerm); err != nil {
-		log.Fatalf("cannot write file %v: %v", config, err)
-	}
 	openssl("req", "-new", "-x509", "-nodes", "-days", "3600", "-batch",
 		"-config", config,
 		"-key", key,
@@ -148,50 +173,118 @@ func CreateSignedCert(root, parent, serial, name, commonName string) {
 		"-out", cert)
 }
 
+// CreateCRL creates a new empty certificate revocation list
+// for the provided parent
+func CreateCRL(root, parent string) {
+	log.Infof("Creating CRL for root CA in %v", root)
+	caKey := path.Join(root, parent+"-key.pem")
+	caCert := path.Join(root, parent+"-cert.pem")
+	configPath := path.Join(root, parent+"-ca.config")
+	crlPath := path.Join(root, parent+"-crl.pem")
+	createKeyDBAndCAConfig(root, parent)
+
+	openssl("ca", "-gencrl",
+		"-keyfile", caKey,
+		"-cert", caCert,
+		"-config", configPath,
+		"-out",
+		crlPath,
+	)
+}
+
+// RevokeCertAndRegenerateCRL revokes a provided certificate under the
+// provided parent CA and regenerates the CRL file for that parent
+func RevokeCertAndRegenerateCRL(root, parent, name string) {
+	log.Infof("Revoking certificate %s", name)
+	caKey := path.Join(root, parent+"-key.pem")
+	caCert := path.Join(root, parent+"-cert.pem")
+	cert := path.Join(root, name+"-cert.pem")
+	configPath := path.Join(root, parent+"-ca.config")
+	createKeyDBAndCAConfig(root, parent)
+
+	openssl("ca", "-revoke", cert,
+		"-keyfile", caKey,
+		"-cert", caCert,
+		"-config", configPath,
+	)
+
+	CreateCRL(root, parent)
+}
+
+// ClientServerKeyPairs is used in tests
 type ClientServerKeyPairs struct {
-	ServerCert string
-	ServerKey  string
-	ServerCA   string
-	ServerName string
-	ClientCert string
-	ClientKey  string
-	ClientCA   string
+	ServerCert        string
+	ServerKey         string
+	ServerCA          string
+	ServerName        string
+	ServerCRL         string
+	RevokedServerCert string
+	RevokedServerKey  string
+	RevokedServerName string
+	ClientCert        string
+	ClientKey         string
+	ClientCA          string
+	ClientCRL         string
+	RevokedClientCert string
+	RevokedClientKey  string
+	RevokedClientName string
 }
 
 var serialCounter = 0
 
+// CreateClientServerCertPairs creates certificate pairs for use in test
 func CreateClientServerCertPairs(root string) ClientServerKeyPairs {
 	// Create the certs and configs.
 	CreateCA(root)
 
-	serverSerial := fmt.Sprintf("%03d", serialCounter*2+1)
-	clientSerial := fmt.Sprintf("%03d", serialCounter*2+2)
+	serverCASerial := fmt.Sprintf("%03d", serialCounter*2+1)
+	serverSerial := fmt.Sprintf("%03d", serialCounter*2+3)
+	revokedServerSerial := fmt.Sprintf("%03d", serialCounter*2+5)
+	clientCASerial := fmt.Sprintf("%03d", serialCounter*2+2)
+	clientCertSerial := fmt.Sprintf("%03d", serialCounter*2+4)
+	revokedClientSerial := fmt.Sprintf("%03d", serialCounter*2+6)
 
-	serialCounter = serialCounter + 1
+	serialCounter = serialCounter + 3
 
-	serverName := fmt.Sprintf("server-%s", serverSerial)
-	serverCACommonName := fmt.Sprintf("Server %s CA", serverSerial)
+	serverCAName := fmt.Sprintf("servers-ca-%s", serverCASerial)
+	serverCACommonName := fmt.Sprintf("Servers %s CA", serverCASerial)
 	serverCertName := fmt.Sprintf("server-instance-%s", serverSerial)
 	serverCertCommonName := fmt.Sprintf("server%s.example.com", serverSerial)
+	revokedServerCertName := fmt.Sprintf("server-instance-%s", revokedServerSerial)
+	revokedServerCertCommonName := fmt.Sprintf("server%s.example.com", revokedServerSerial)
 
-	clientName := fmt.Sprintf("clients-%s", serverSerial)
-	clientCACommonName := fmt.Sprintf("Clients %s CA", serverSerial)
-	clientCertName := fmt.Sprintf("client-instance-%s", serverSerial)
-	clientCertCommonName := fmt.Sprintf("Client Instance %s", serverSerial)
+	clientCAName := fmt.Sprintf("clients-ca-%s", clientCASerial)
+	clientCACommonName := fmt.Sprintf("Clients %s CA", clientCASerial)
+	clientCertName := fmt.Sprintf("client-instance-%s", clientCertSerial)
+	clientCertCommonName := fmt.Sprintf("client%s.example.com", clientCertSerial)
+	revokedClientCertName := fmt.Sprintf("client-instance-%s", revokedClientSerial)
+	revokedClientCertCommonName := fmt.Sprintf("client%s.example.com", revokedClientSerial)
 
-	CreateSignedCert(root, CA, serverSerial, serverName, serverCACommonName)
-	CreateSignedCert(root, serverName, serverSerial, serverCertName, serverCertCommonName)
+	CreateSignedCert(root, CA, serverCASerial, serverCAName, serverCACommonName)
+	CreateSignedCert(root, serverCAName, serverSerial, serverCertName, serverCertCommonName)
+	CreateSignedCert(root, serverCAName, revokedServerSerial, revokedServerCertName, revokedServerCertCommonName)
+	RevokeCertAndRegenerateCRL(root, serverCAName, revokedServerCertName)
 
-	CreateSignedCert(root, CA, clientSerial, clientName, clientCACommonName)
-	CreateSignedCert(root, clientName, serverSerial, clientCertName, clientCertCommonName)
+	CreateSignedCert(root, CA, clientCASerial, clientCAName, clientCACommonName)
+	CreateSignedCert(root, clientCAName, clientCertSerial, clientCertName, clientCertCommonName)
+	CreateSignedCert(root, clientCAName, revokedClientSerial, revokedClientCertName, revokedClientCertCommonName)
+	RevokeCertAndRegenerateCRL(root, clientCAName, revokedClientCertName)
 
 	return ClientServerKeyPairs{
-		ServerCert: path.Join(root, fmt.Sprintf("%s-cert.pem", serverCertName)),
-		ServerKey:  path.Join(root, fmt.Sprintf("%s-key.pem", serverCertName)),
-		ServerCA:   path.Join(root, fmt.Sprintf("%s-cert.pem", serverName)),
-		ClientCert: path.Join(root, fmt.Sprintf("%s-cert.pem", clientCertName)),
-		ClientKey:  path.Join(root, fmt.Sprintf("%s-key.pem", clientCertName)),
-		ClientCA:   path.Join(root, fmt.Sprintf("%s-cert.pem", clientName)),
-		ServerName: serverCertCommonName,
+		ServerCert:        path.Join(root, fmt.Sprintf("%s-cert.pem", serverCertName)),
+		ServerKey:         path.Join(root, fmt.Sprintf("%s-key.pem", serverCertName)),
+		ServerCA:          path.Join(root, fmt.Sprintf("%s-cert.pem", serverCAName)),
+		ServerCRL:         path.Join(root, fmt.Sprintf("%s-crl.pem", serverCAName)),
+		RevokedServerCert: path.Join(root, fmt.Sprintf("%s-cert.pem", revokedServerCertName)),
+		RevokedServerKey:  path.Join(root, fmt.Sprintf("%s-key.pem", revokedServerCertName)),
+		ClientCert:        path.Join(root, fmt.Sprintf("%s-cert.pem", clientCertName)),
+		ClientKey:         path.Join(root, fmt.Sprintf("%s-key.pem", clientCertName)),
+		ClientCA:          path.Join(root, fmt.Sprintf("%s-cert.pem", clientCAName)),
+		ClientCRL:         path.Join(root, fmt.Sprintf("%s-crl.pem", clientCAName)),
+		RevokedClientCert: path.Join(root, fmt.Sprintf("%s-cert.pem", revokedClientCertName)),
+		RevokedClientKey:  path.Join(root, fmt.Sprintf("%s-key.pem", revokedClientCertName)),
+		ServerName:        serverCertCommonName,
+		RevokedServerName: revokedServerCertCommonName,
+		RevokedClientName: revokedClientCertCommonName,
 	}
 }

--- a/go/vt/tlstest/tlstest_test.go
+++ b/go/vt/tlstest/tlstest_test.go
@@ -66,6 +66,7 @@ func testClientServer(t *testing.T, combineCerts bool) {
 		clientServerKeyPairs.ServerCert,
 		clientServerKeyPairs.ServerKey,
 		clientServerKeyPairs.ClientCA,
+		clientServerKeyPairs.ClientCRL,
 		serverCA,
 		tls.VersionTLS12)
 	if err != nil {
@@ -76,6 +77,7 @@ func testClientServer(t *testing.T, combineCerts bool) {
 		clientServerKeyPairs.ClientCert,
 		clientServerKeyPairs.ClientKey,
 		clientServerKeyPairs.ServerCA,
+		clientServerKeyPairs.ServerCRL,
 		clientServerKeyPairs.ServerName,
 		tls.VersionTLS12)
 	if err != nil {
@@ -110,9 +112,6 @@ func testClientServer(t *testing.T, combineCerts bool) {
 	}()
 
 	serverConn, err := listener.Accept()
-	if clientErr != nil {
-		t.Fatalf("Dial failed: %v", clientErr)
-	}
 	if err != nil {
 		t.Fatalf("Accept failed: %v", err)
 	}
@@ -128,6 +127,10 @@ func testClientServer(t *testing.T, combineCerts bool) {
 
 	wg.Wait()
 
+	if clientErr != nil {
+		t.Fatalf("Dial failed: %v", clientErr)
+	}
+
 	//
 	// Negative case: connect a client with wrong cert (using the
 	// server cert on the client side).
@@ -138,6 +141,7 @@ func testClientServer(t *testing.T, combineCerts bool) {
 		clientServerKeyPairs.ServerCert,
 		clientServerKeyPairs.ServerKey,
 		clientServerKeyPairs.ServerCA,
+		clientServerKeyPairs.ServerCRL,
 		clientServerKeyPairs.ServerName,
 		tls.VersionTLS12)
 	if err != nil {
@@ -189,6 +193,7 @@ func getServerConfigWithoutCombinedCerts(keypairs ClientServerKeyPairs) (*tls.Co
 		keypairs.ServerCert,
 		keypairs.ServerKey,
 		keypairs.ClientCA,
+		keypairs.ClientCRL,
 		"",
 		tls.VersionTLS12)
 }
@@ -198,6 +203,7 @@ func getServerConfigWithCombinedCerts(keypairs ClientServerKeyPairs) (*tls.Confi
 		keypairs.ServerCert,
 		keypairs.ServerKey,
 		keypairs.ClientCA,
+		keypairs.ClientCRL,
 		keypairs.ServerCA,
 		tls.VersionTLS12)
 }
@@ -208,6 +214,7 @@ func getClientConfig(keypairs ClientServerKeyPairs) (*tls.Config, error) {
 		keypairs.ClientCert,
 		keypairs.ClientKey,
 		keypairs.ServerCA,
+		keypairs.ServerCRL,
 		keypairs.ServerName,
 		tls.VersionTLS12)
 }
@@ -297,6 +304,7 @@ func testNumberOfCertsWithOrWithoutCombining(t *testing.T, numCertsExpected int,
 		clientServerKeyPairs.ServerCert,
 		clientServerKeyPairs.ServerKey,
 		clientServerKeyPairs.ClientCA,
+		clientServerKeyPairs.ClientCRL,
 		serverCA,
 		tls.VersionTLS12)
 
@@ -312,4 +320,118 @@ func TestNumberOfCertsWithoutCombining(t *testing.T) {
 
 func TestNumberOfCertsWithCombining(t *testing.T) {
 	testNumberOfCertsWithOrWithoutCombining(t, 2, true)
+}
+
+func assertTLSHandshakeFails(t *testing.T, serverConfig, clientConfig *tls.Config) {
+	// Create a TLS server listener.
+	listener, err := tls.Listen("tcp", ":0", serverConfig)
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+	addr := listener.Addr().String()
+	defer listener.Close()
+	// create a dialer with timeout
+	dialer := new(net.Dialer)
+	dialer.Timeout = 10 * time.Second
+
+	wg := sync.WaitGroup{}
+
+	var clientErr error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var clientConn *tls.Conn
+		clientConn, clientErr = tls.DialWithDialer(dialer, "tcp", addr, clientConfig)
+		if clientErr == nil {
+			clientConn.Close()
+		}
+	}()
+
+	serverConn, err := listener.Accept()
+	if err != nil {
+		// We should always be able to accept on the socket
+		t.Fatalf("Accept failed: %v", err)
+	}
+
+	err = serverConn.(*tls.Conn).Handshake()
+	if err != nil {
+		if !(strings.Contains(err.Error(), "Certificate revoked: CommonName=") ||
+			strings.Contains(err.Error(), "remote error: tls: bad certificate")) {
+			t.Fatalf("Wrong error returned: %v", err)
+		}
+	} else {
+		t.Fatal("Server should have failed the TLS handshake but it did not")
+	}
+	serverConn.Close()
+	wg.Wait()
+}
+
+func TestClientServerWithRevokedServerCert(t *testing.T) {
+	root, err := ioutil.TempDir("", "tlstest")
+	if err != nil {
+		t.Fatalf("TempDir failed: %v", err)
+	}
+	defer os.RemoveAll(root)
+
+	clientServerKeyPairs := CreateClientServerCertPairs(root)
+
+	serverConfig, err := vttls.ServerConfig(
+		clientServerKeyPairs.RevokedServerCert,
+		clientServerKeyPairs.RevokedServerKey,
+		clientServerKeyPairs.ClientCA,
+		clientServerKeyPairs.ClientCRL,
+		"",
+		tls.VersionTLS12)
+	if err != nil {
+		t.Fatalf("TLSServerConfig failed: %v", err)
+	}
+
+	clientConfig, err := vttls.ClientConfig(
+		vttls.VerifyIdentity,
+		clientServerKeyPairs.ClientCert,
+		clientServerKeyPairs.ClientKey,
+		clientServerKeyPairs.ServerCA,
+		clientServerKeyPairs.ServerCRL,
+		clientServerKeyPairs.RevokedServerName,
+		tls.VersionTLS12)
+	if err != nil {
+		t.Fatalf("TLSClientConfig failed: %v", err)
+	}
+
+	assertTLSHandshakeFails(t, serverConfig, clientConfig)
+}
+
+func TestClientServerWithRevokedClientCert(t *testing.T) {
+	root, err := ioutil.TempDir("", "tlstest")
+	if err != nil {
+		t.Fatalf("TempDir failed: %v", err)
+	}
+	defer os.RemoveAll(root)
+
+	clientServerKeyPairs := CreateClientServerCertPairs(root)
+
+	serverConfig, err := vttls.ServerConfig(
+		clientServerKeyPairs.ServerCert,
+		clientServerKeyPairs.ServerKey,
+		clientServerKeyPairs.ClientCA,
+		clientServerKeyPairs.ClientCRL,
+		"",
+		tls.VersionTLS12)
+	if err != nil {
+		t.Fatalf("TLSServerConfig failed: %v", err)
+	}
+
+	clientConfig, err := vttls.ClientConfig(
+		vttls.VerifyIdentity,
+		clientServerKeyPairs.RevokedClientCert,
+		clientServerKeyPairs.RevokedClientKey,
+		clientServerKeyPairs.ServerCA,
+		clientServerKeyPairs.ServerCRL,
+		clientServerKeyPairs.ServerName,
+		tls.VersionTLS12)
+	if err != nil {
+		t.Fatalf("TLSClientConfig failed: %v", err)
+	}
+
+	assertTLSHandshakeFails(t, serverConfig, clientConfig)
 }

--- a/go/vt/vtctl/grpcclientcommon/dial_option.go
+++ b/go/vt/vtctl/grpcclientcommon/dial_option.go
@@ -30,6 +30,7 @@ var (
 	cert = flag.String("vtctld_grpc_cert", "", "the cert to use to connect")
 	key  = flag.String("vtctld_grpc_key", "", "the key to use to connect")
 	ca   = flag.String("vtctld_grpc_ca", "", "the server ca to use to validate servers when connecting")
+	crl  = flag.String("vtctld_grpc_crl", "", "the server crl to use to validate server certificates when connecting")
 	name = flag.String("vtctld_grpc_server_name", "", "the server name to use to validate server certificate")
 )
 
@@ -37,5 +38,5 @@ var (
 // insecure if no flags were set) based on the vtctld_grpc_* flags declared by
 // this package.
 func SecureDialOption() (grpc.DialOption, error) {
-	return grpcclient.SecureDialOption(*cert, *key, *ca, *name)
+	return grpcclient.SecureDialOption(*cert, *key, *ca, *crl, *name)
 }

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -41,6 +41,7 @@ var (
 	cert = flag.String("vtgate_grpc_cert", "", "the cert to use to connect")
 	key  = flag.String("vtgate_grpc_key", "", "the key to use to connect")
 	ca   = flag.String("vtgate_grpc_ca", "", "the server ca to use to validate servers when connecting")
+	crl  = flag.String("vtgate_grpc_crl", "", "the server crl to use to validate server certificates when connecting")
 	name = flag.String("vtgate_grpc_server_name", "", "the server name to use to validate server certificate")
 )
 
@@ -60,7 +61,7 @@ func dial(ctx context.Context, addr string) (vtgateconn.Impl, error) {
 // DialWithOpts allows for custom dial options to be set on a vtgateConn.
 func DialWithOpts(ctx context.Context, opts ...grpc.DialOption) vtgateconn.DialerFunc {
 	return func(ctx context.Context, address string) (vtgateconn.Impl, error) {
-		opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
+		opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *crl, *name)
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -265,6 +265,7 @@ func testInitTLSConfig(t *testing.T, serverCA bool) {
 	}
 	defer os.RemoveAll(root)
 	tlstest.CreateCA(root)
+	tlstest.CreateCRL(root, tlstest.CA)
 	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
 
 	serverCACert := ""
@@ -273,7 +274,7 @@ func testInitTLSConfig(t *testing.T, serverCA bool) {
 	}
 
 	listener := &mysql.Listener{}
-	if err := initTLSConfig(listener, path.Join(root, "server-cert.pem"), path.Join(root, "server-key.pem"), path.Join(root, "ca-cert.pem"), serverCACert, true, tls.VersionTLS12); err != nil {
+	if err := initTLSConfig(listener, path.Join(root, "server-cert.pem"), path.Join(root, "server-key.pem"), path.Join(root, "ca-cert.pem"), path.Join(root, "ca-crl.pem"), serverCACert, true, tls.VersionTLS12); err != nil {
 		t.Fatalf("init tls config failure due to: +%v", err)
 	}
 

--- a/go/vt/vtgate/querylogz.go
+++ b/go/vt/vtgate/querylogz.go
@@ -105,9 +105,9 @@ func querylogzHandler(ch chan interface{}, w http.ResponseWriter, r *http.Reques
 			stats, ok := out.(*LogStats)
 			if !ok {
 				err := fmt.Errorf("unexpected value in %s: %#v (expecting value of type %T)", QueryLogger.Name(), out, &LogStats{})
-				io.WriteString(w, `<tr class="error">`)
-				io.WriteString(w, err.Error())
-				io.WriteString(w, "</tr>")
+				_, _ = io.WriteString(w, `<tr class="error">`)
+				_, _ = io.WriteString(w, err.Error())
+				_, _ = io.WriteString(w, "</tr>")
 				log.Error(err)
 				continue
 			}

--- a/go/vt/vttablet/grpctabletconn/conn.go
+++ b/go/vt/vttablet/grpctabletconn/conn.go
@@ -44,6 +44,7 @@ var (
 	cert = flag.String("tablet_grpc_cert", "", "the cert to use to connect")
 	key  = flag.String("tablet_grpc_key", "", "the key to use to connect")
 	ca   = flag.String("tablet_grpc_ca", "", "the server ca to use to validate servers when connecting")
+	crl  = flag.String("tablet_grpc_crl", "", "the server crl to use to validate server certificates when connecting")
 	name = flag.String("tablet_grpc_server_name", "", "the server name to use to validate server certificate")
 )
 
@@ -73,7 +74,7 @@ func DialTablet(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (querys
 	} else {
 		addr = tablet.Hostname
 	}
-	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
+	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *crl, *name)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/grpctmclient/cached_client.go
+++ b/go/vt/vttablet/grpctmclient/cached_client.go
@@ -230,7 +230,7 @@ func (dialer *cachedConnDialer) pollOnce(ctx context.Context, addr string) (clie
 // It returns the three-tuple of client-interface, closer, and error that the
 // main dial func returns.
 func (dialer *cachedConnDialer) newdial(ctx context.Context, addr string) (tabletmanagerservicepb.TabletManagerClient, io.Closer, error) {
-	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
+	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *crl, *name)
 	if err != nil {
 		dialer.connWaitSema.Release()
 		return nil, nil, err

--- a/go/vt/vttablet/grpctmclient/client.go
+++ b/go/vt/vttablet/grpctmclient/client.go
@@ -48,6 +48,7 @@ var (
 	cert        = flag.String("tablet_manager_grpc_cert", "", "the cert to use to connect")
 	key         = flag.String("tablet_manager_grpc_key", "", "the key to use to connect")
 	ca          = flag.String("tablet_manager_grpc_ca", "", "the server ca to use to validate servers when connecting")
+	crl         = flag.String("tablet_manager_grpc_crl", "", "the server crl to use to validate server certificates when connecting")
 	name        = flag.String("tablet_manager_grpc_server_name", "", "the server name to use to validate server certificate")
 )
 
@@ -111,7 +112,7 @@ func NewClient() *Client {
 // dial returns a client to use
 func (client *grpcClient) dial(ctx context.Context, tablet *topodatapb.Tablet) (tabletmanagerservicepb.TabletManagerClient, io.Closer, error) {
 	addr := netutil.JoinHostPort(tablet.Hostname, int32(tablet.PortMap["grpc"]))
-	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
+	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *crl, *name)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -125,7 +126,7 @@ func (client *grpcClient) dial(ctx context.Context, tablet *topodatapb.Tablet) (
 
 func (client *grpcClient) dialPool(ctx context.Context, tablet *topodatapb.Tablet) (tabletmanagerservicepb.TabletManagerClient, error) {
 	addr := netutil.JoinHostPort(tablet.Hostname, int32(tablet.PortMap["grpc"]))
-	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
+	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *crl, *name)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttls/crl.go
+++ b/go/vt/vttls/crl.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vttls
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	"vitess.io/vitess/go/vt/log"
+)
+
+type verifyPeerCertificateFunc func([][]byte, [][]*x509.Certificate) error
+
+func certIsRevoked(cert *x509.Certificate, crl *pkix.CertificateList) bool {
+	if crl.HasExpired(time.Now()) {
+		log.Warningf("The current Certificate Revocation List (CRL) is past expiry date and must be updated. Revoked certificates will still be rejected in this state.")
+	}
+
+	for _, revoked := range crl.TBSCertList.RevokedCertificates {
+		if cert.SerialNumber.Cmp(revoked.SerialNumber) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func verifyPeerCertificateAgainstCRL(crl string) (verifyPeerCertificateFunc, error) {
+	body, err := ioutil.ReadFile(crl)
+	if err != nil {
+		return nil, err
+	}
+
+	parsedCRL, err := x509.ParseCRL(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(_ [][]byte, verifiedChains [][]*x509.Certificate) error {
+		for _, chain := range verifiedChains {
+			for _, cert := range chain {
+				if certIsRevoked(cert, parsedCRL) {
+					return fmt.Errorf("Certificate revoked: CommonName=%v", cert.Subject.CommonName)
+				}
+			}
+		}
+		return nil
+	}, nil
+}

--- a/go/vt/worker/grpcvtworkerclient/client.go
+++ b/go/vt/worker/grpcvtworkerclient/client.go
@@ -39,6 +39,7 @@ var (
 	cert = flag.String("vtworker_client_grpc_cert", "", "the cert to use to connect")
 	key  = flag.String("vtworker_client_grpc_key", "", "the key to use to connect")
 	ca   = flag.String("vtworker_client_grpc_ca", "", "the server ca to use to validate servers when connecting")
+	crl  = flag.String("vtworker_client_grpc_crl", "", "the server crl to use to validate server certificates when connecting")
 	name = flag.String("vtworker_client_grpc_server_name", "", "the server name to use to validate server certificate")
 )
 
@@ -49,7 +50,7 @@ type gRPCVtworkerClient struct {
 
 func gRPCVtworkerClientFactory(addr string) (vtworkerclient.Client, error) {
 	// create the RPC client
-	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
+	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *crl, *name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Hormoz Kheradmand <hormoz.kheradmand@shopify.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

### Background

Certificate Revocation Lists (CRLs) are lists of certificates that have been revoked by the Certificate Authority (CA) before they were due to expire. Support for CRL files were added to mysql many years ago (see https://bugs.mysql.com/bug.php?id=31224)

A CRL lists certificates by their uniquely identifiable serial number. The CA is responsible for tracking this and issuing the CRL. For example, in our case, the [Hashicorp Vault PKI secrets engine](https://www.vaultproject.io/docs/secrets/pki) issue these CRL files and we can upload the resulting PEM file to our infrastructure. 

We have this implemented for our MySQL container, proxysql containers, and we would like to add this feature to Vitess, so that we are prepared for the event where we need to revoke any of our certificates.

### Changes in PR

This PR adds the CRL option to various network links in Vitess:

* Implement a CRL check in `vttls.go`, using the `tls` package's `VerifyPeerCertificate` extension hook.

```
	// VerifyPeerCertificate, if not nil, is called after normal
	// certificate verification by either a TLS client or server. It
	// receives the raw ASN.1 certificates provided by the peer and also
	// any verified chains that normal processing found. If it returns a
	// non-nil error, the handshake is aborted and that error results.
	//
	// If normal verification fails then the handshake will abort before
	// considering this callback. If normal verification is disabled by
	// setting InsecureSkipVerify, or (for a server) when ClientAuth is
	// RequestClientCert or RequireAnyClientCert, then this callback will
	// be considered but the verifiedChains argument will always be nil.
	VerifyPeerCertificate func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error
```

* Wire up a path-to-CRL-file option (e.g. `grpc_crl`, `tablet_grpc_crl`, ...)  for various usages:
  * Servers (listeners) verifying incoming connections (`ServerConfig` callers)
    * Vtgate MySQL server
    * GRPC server
  * Clients verifying downstream servers (`ClientConfig` callers)
    * LDAP_auth_server clients
    * GRPC clients
    * MySQL clients

Since I am not very familiar with running a "fully managed" tablet through `mysqlctl`, I am not sure if my work covers the communication links between various vttablets.. In our infrastructure, we had to modify our replication setup statement (add the `MASTER_SSL_CRL = 'crl_file_name'` to our `CHANGE MASTER TO` statement).

### Offline vs online CRL checks

Please note that this PR only adds the ability to specify a path to CRL files.

Out in the open internet, CRLs are fetched from "distribution endpoints" (URLs) that are specified as a field on the client/server's certificate file. However online checks come with interesting challenges, such as "what do you do when the endpoint itself is down?" or "can an attacker DoS your CRL endpoint, rendering your CRL checks ineffective?"

Note that MySQL itself is also lacking the "online check" (see https://bugs.mysql.com/bug.php?id=75387)

### Q&A

* **What happens if the CRL file doesn't exist or cannot be read?** In that case, the Vitess process will most likely fail to start up since the CRL file is read as soon as either `vttls.ServerConfig` or `vttls.ClientConfig` are called.

* **What happens if the CRL file itself needs to be updated (is past its `updateAfter` field)?** In that case, we choose to still use the CRL. i.e. we will reject revoked certificates but log a warning for the user to update their CRL file.


## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

All new code here is behind optional arguments – I don't think we need any special considerations.