### PR TITLE
Put .git folders in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ releases
 /vthook/
 /bin/
 /vtdataroot/
+**/.git


### PR DESCRIPTION
ShopifyBuild uses docker buildx that conflicts with folders that contain symlinks: https://github.com/docker/buildx/issues/150
We need to ignore .git folder to successfully migrate vitess-build to ShopifyBuild.

Related to: Shopify/vitess-build#11