### PR TITLE
Better solution to buildx issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,4 +9,3 @@ releases
 /vthook/
 /bin/
 /vtdataroot/
-**/.git

--- a/build.env
+++ b/build.env
@@ -38,9 +38,14 @@ ln -snf "$PWD/test/vthook-test_backup_error" vthook/test_backup_error
 ln -snf "$PWD/test/vthook-test_backup_transform" vthook/test_backup_transform
 
 # install git hooks
+if [ -d .git ]
+then
+    mkdir -p .git/hooks
+    ln -sf "$PWD/misc/git/pre-commit" .git/hooks/pre-commit
+    ln -sf "$PWD/misc/git/commit-msg" .git/hooks/commit-msg
+    git config core.hooksPath .git/hooks
+else
+    echo "WARN: Seems like we're not in a git repository; skipped installing git hooks"
+fi
 
-mkdir -p .git/hooks
-ln -sf "$PWD/misc/git/pre-commit" .git/hooks/pre-commit
-ln -sf "$PWD/misc/git/commit-msg" .git/hooks/commit-msg
-git config core.hooksPath .git/hooks
 export EXTRA_BIN=$PWD/test/bin


### PR DESCRIPTION
Reverts the previously-introduced patch in https://github.com/Shopify/vitess/pull/38 and fixes the container build issue with something more sustainable and upstream-able.

Our "final" Vitess containers are built in 3 stages (refer to [sample build](https://buildkite.com/shopify/vitess-build/builds/112#0181cf69-c2be-4a2c-adcb-9a59603155c1)):

1. Build a "common" base image, aka `vitess/common`
2. Build a middle image with the correct mysql version, aka `vitess/mysql57`
3. Build final images for production usage, such as `vitess/vttestserver-mysql57` or `vitess/lite-mysql57`

Turns out that the middle image was running `source build.env` as part of its build process, which creates a `.git` directory tree in the middle image to make sure that git hooks are installed and configured for the user.. 

The final images are built by copying the whole source directory into the container (though they're then stripped away before finalizing the build) but `docker buildx build` doesn't like to replace directories as `docker build` does. BuildX probably does the more correct/predictable thing but it does break backwards compatability.

The `.git` folder is actually stripped away from all the containers that we produce in the end, so this patch only resolves a conflict in a middle state.