### PR TITLE
Add new placement Vindex strategy

### DIFF
--- a/go/vt/key/key.go
+++ b/go/vt/key/key.go
@@ -113,10 +113,10 @@ func KeyRangeAdd(first, second *topodatapb.KeyRange) (*topodatapb.KeyRange, bool
 	if first == nil || second == nil {
 		return nil, false
 	}
-	if len(first.End) != 0 && bytes.Equal(first.End, second.Start) {
+	if len(first.End) != 0 && bytes.Equal(addPadding(first.End), addPadding(second.Start)) {
 		return &topodatapb.KeyRange{Start: first.Start, End: second.End}, true
 	}
-	if len(second.End) != 0 && bytes.Equal(second.End, first.Start) {
+	if len(second.End) != 0 && bytes.Equal(addPadding(second.End), addPadding(first.Start)) {
 		return &topodatapb.KeyRange{Start: second.Start, End: first.End}, true
 	}
 	return nil, false
@@ -127,8 +127,8 @@ func KeyRangeContains(kr *topodatapb.KeyRange, id []byte) bool {
 	if kr == nil {
 		return true
 	}
-	return bytes.Compare(kr.Start, id) <= 0 &&
-		(len(kr.End) == 0 || bytes.Compare(id, kr.End) < 0)
+	return bytes.Compare(addPadding(kr.Start), addPadding(id)) <= 0 &&
+		(len(kr.End) == 0 || bytes.Compare(addPadding(id), addPadding(kr.End)) < 0)
 }
 
 // ParseKeyRangeParts parses a start and end hex values and build a proto KeyRange
@@ -202,7 +202,7 @@ func KeyRangeStartSmaller(left, right *topodatapb.KeyRange) bool {
 	if right == nil {
 		return false
 	}
-	return bytes.Compare(left.Start, right.Start) < 0
+	return bytes.Compare(addPadding(left.Start), addPadding(right.Start)) < 0
 }
 
 // KeyRangeStartEqual returns true if both key ranges have the same start
@@ -250,8 +250,8 @@ func KeyRangesIntersect(first, second *topodatapb.KeyRange) bool {
 	if first == nil || second == nil {
 		return true
 	}
-	return (len(first.End) == 0 || bytes.Compare(second.Start, first.End) < 0) &&
-		(len(second.End) == 0 || bytes.Compare(first.Start, second.End) < 0)
+	return (len(first.End) == 0 || bytes.Compare(addPadding(second.Start), addPadding(first.End)) < 0) &&
+		(len(second.End) == 0 || bytes.Compare(addPadding(first.Start), addPadding(second.End)) < 0)
 }
 
 // KeyRangesOverlap returns the overlap between two KeyRanges.
@@ -270,14 +270,14 @@ func KeyRangesOverlap(first, second *topodatapb.KeyRange) (*topodatapb.KeyRange,
 	// start with (a,b)
 	result := proto.Clone(first).(*topodatapb.KeyRange)
 	// if c > a, then use c
-	if bytes.Compare(second.Start, first.Start) > 0 {
+	if bytes.Compare(addPadding(second.Start), addPadding(first.Start)) > 0 {
 		result.Start = second.Start
 	}
 	// if b is maxed out, or
 	// (d is not maxed out and d < b)
 	//                           ^ valid test as neither b nor d are max
 	// then use d
-	if len(first.End) == 0 || (len(second.End) != 0 && bytes.Compare(second.End, first.End) < 0) {
+	if len(first.End) == 0 || (len(second.End) != 0 && bytes.Compare(addPadding(second.End), addPadding(first.End)) < 0) {
 		result.End = second.End
 	}
 	return result, nil
@@ -297,10 +297,10 @@ func KeyRangeIncludes(big, small *topodatapb.KeyRange) bool {
 		return len(big.Start) == 0 && len(big.End) == 0
 	}
 	// Now we check small.Start >= big.Start, and small.End <= big.End
-	if len(big.Start) != 0 && bytes.Compare(small.Start, big.Start) < 0 {
+	if len(big.Start) != 0 && bytes.Compare(addPadding(small.Start), addPadding(big.Start)) < 0 {
 		return false
 	}
-	if len(big.End) != 0 && (len(small.End) == 0 || bytes.Compare(small.End, big.End) > 0) {
+	if len(big.End) != 0 && (len(small.End) == 0 || bytes.Compare(addPadding(small.End), addPadding(big.End)) > 0) {
 		return false
 	}
 	return true

--- a/go/vt/vtgate/vindexes/placement.go
+++ b/go/vt/vtgate/vindexes/placement.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+
+A Vindex which uses a mapping lookup table `placement_map` to set the first `placement_prefix_bytes` of the Keyspace ID
+and another Vindex type `placement_sub_vindex_type` (which must support Hashing) as a sub-Vindex to set the rest.
+This is suitable for regional sharding (like region_json or region_experimental) but does not require a mapping file,
+and can support non-integer types for the sharding column. All parameters are prefixed with `placement_` so as to avoid
+conflict, because the `params` map is passed to the sub-Vindex as well.
+
+*/
+
+package vindexes
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/key"
+)
+
+var (
+	_ MultiColumn = (*Placement)(nil)
+
+	PlacementRequiredParams = []string{
+		"placement_map",
+		"placement_prefix_bytes",
+		"placement_sub_vindex_type",
+	}
+)
+
+func init() {
+	Register("placement", NewPlacement)
+}
+
+type PlacementMap map[string]uint64
+
+type Placement struct {
+	name          string
+	placementMap  PlacementMap
+	subVindex     Vindex
+	subVindexType string
+	subVindexName string
+	prefixBytes   int
+}
+
+// Parse a string containing a list of delimited string:integer key-value pairs, e.g. "foo:1,bar:2".
+func parsePlacementMap(s string) (*PlacementMap, error) {
+	placementMap := make(PlacementMap)
+	for _, entry := range strings.Split(s, ",") {
+		if entry == "" {
+			continue
+		}
+
+		kv := strings.Split(entry, ":")
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("entry: %v; expected key:value", entry)
+		}
+		if kv[0] == "" {
+			return nil, fmt.Errorf("entry: %v; unexpected empty key", entry)
+		}
+		if kv[1] == "" {
+			return nil, fmt.Errorf("entry: %v; unexpected empty value", entry)
+		}
+
+		value, err := strconv.ParseUint(kv[1], 0, 64)
+		if err != nil {
+			return nil, fmt.Errorf("entry: %v; %v", entry, err)
+		}
+		placementMap[kv[0]] = value
+	}
+	return &placementMap, nil
+}
+
+func NewPlacement(name string, params map[string]string) (Vindex, error) {
+	var missingParams []string
+	for _, param := range PlacementRequiredParams {
+		if params[param] == "" {
+			missingParams = append(missingParams, param)
+		}
+	}
+
+	if len(missingParams) > 0 {
+		return nil, fmt.Errorf("missing params: %s", strings.Join(missingParams, ", "))
+	}
+
+	placementMap, parseError := parsePlacementMap(params["placement_map"])
+	if parseError != nil {
+		return nil, fmt.Errorf("malformed placement_map; %v", parseError)
+	}
+
+	prefixBytes, prefixError := strconv.Atoi(params["placement_prefix_bytes"])
+	if prefixError != nil {
+		return nil, prefixError
+	}
+
+	if prefixBytes < 1 || prefixBytes > 7 {
+		return nil, fmt.Errorf("invalid placement_prefix_bytes: %v; expected integer between 1 and 7", prefixBytes)
+	}
+
+	subVindexType := params["placement_sub_vindex_type"]
+	subVindexName := fmt.Sprintf("%s_sub_vindex", name)
+	subVindex, createVindexError := CreateVindex(subVindexType, subVindexName, params)
+	if createVindexError != nil {
+		return nil, fmt.Errorf("invalid placement_sub_vindex_type: %v", createVindexError)
+	}
+
+	// TODO: Should we support MultiColumn Vindex?
+	if _, subVindexSupportsHashing := subVindex.(Hashing); !subVindexSupportsHashing {
+		return nil, fmt.Errorf("invalid placement_sub_vindex_type: %v; does not support the Hashing interface", createVindexError)
+	}
+
+	return &Placement{
+		name:          name,
+		placementMap:  *placementMap,
+		subVindex:     subVindex,
+		subVindexType: subVindexType,
+		subVindexName: subVindexName,
+		prefixBytes:   prefixBytes,
+	}, nil
+}
+
+func (p *Placement) String() string {
+	return p.name
+}
+
+func (p *Placement) Cost() int {
+	return 1
+}
+
+func (p *Placement) IsUnique() bool {
+	return true
+}
+
+func (p *Placement) NeedsVCursor() bool {
+	return false
+}
+
+func (p *Placement) PartialVindex() bool {
+	return false
+}
+
+func (p *Placement) Map(ctx context.Context, vcursor VCursor, rowsColValues [][]sqltypes.Value) ([]key.Destination, error) {
+	destinations := make([]key.Destination, 0, len(rowsColValues))
+
+	for _, row := range rowsColValues {
+		if len(row) != 2 {
+			destinations = append(destinations, key.DestinationNone{})
+			continue
+		}
+
+		placementKey := row[0].ToString()
+		placementDestinationValue, placementMappingFound := p.placementMap[placementKey]
+		if !placementMappingFound {
+			destinations = append(destinations, key.DestinationNone{})
+			continue
+		}
+
+		placementDestinationPrefix := make([]byte, 8)
+		binary.BigEndian.PutUint64(placementDestinationPrefix, placementDestinationValue)
+		if p.prefixBytes < 8 {
+			// Shorten the prefix to the desired length.
+			placementDestinationPrefix = placementDestinationPrefix[(8 - p.prefixBytes):]
+		}
+
+		subVindexValue, hashingError := p.subVindex.(Hashing).Hash(row[1])
+		if hashingError != nil {
+			return nil, hashingError // TODO: Should we be less fatal here and use DestinationNone?
+		}
+
+		// Concatenate and add to destinations.
+		rowDestination := append(placementDestinationPrefix, subVindexValue...)
+		destinations = append(destinations, key.DestinationKeyspaceID(rowDestination[0:8]))
+	}
+
+	return destinations, nil
+}
+
+func (p *Placement) Verify(ctx context.Context, vcursor VCursor, rowsColValues [][]sqltypes.Value, keyspaceIDs [][]byte) ([]bool, error) {
+	result := make([]bool, len(rowsColValues))
+	destinations, _ := p.Map(ctx, vcursor, rowsColValues)
+	for i, destination := range destinations {
+		destinationKeyspaceID, ok := destination.(key.DestinationKeyspaceID)
+		if !ok {
+			continue
+		}
+		result[i] = bytes.Equal(destinationKeyspaceID, keyspaceIDs[i])
+	}
+	return result, nil
+}

--- a/go/vt/vtgate/vindexes/placement_test.go
+++ b/go/vt/vtgate/vindexes/placement_test.go
@@ -1,0 +1,290 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vindexes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/key"
+)
+
+func createBasicPlacementVindex(t *testing.T) (Vindex, error) {
+	return CreateVindex("placement", "placement", map[string]string{
+		"table":                     "t",
+		"from":                      "f1,f2",
+		"to":                        "toc",
+		"placement_prefix_bytes":    "1",
+		"placement_map":             "foo:1,bar:2",
+		"placement_sub_vindex_type": "xxhash",
+	})
+}
+
+func TestPlacementName(t *testing.T) {
+	vindex, err := createBasicPlacementVindex(t)
+	require.NoError(t, err)
+	assert.Equal(t, "placement", vindex.String())
+}
+
+func TestPlacementCost(t *testing.T) {
+	vindex, err := createBasicPlacementVindex(t)
+	require.NoError(t, err)
+	assert.Equal(t, 1, vindex.Cost())
+}
+
+func TestPlacementIsUnique(t *testing.T) {
+	vindex, err := createBasicPlacementVindex(t)
+	require.NoError(t, err)
+	assert.True(t, vindex.IsUnique())
+}
+
+func TestPlacementNeedsVCursor(t *testing.T) {
+	vindex, err := createBasicPlacementVindex(t)
+	require.NoError(t, err)
+	assert.False(t, vindex.NeedsVCursor())
+}
+
+func TestPlacementNoParams(t *testing.T) {
+	_, err := CreateVindex("placement", "placement", nil)
+	assert.EqualError(t, err, "missing params: placement_map, placement_prefix_bytes, placement_sub_vindex_type")
+}
+
+func TestPlacementPlacementMapMissing(t *testing.T) {
+	_, err := CreateVindex("placement", "placement", map[string]string{
+		"placement_prefix_bytes":    "1",
+		"placement_sub_vindex_type": "hash",
+	})
+	assert.EqualError(t, err, "missing params: placement_map")
+}
+
+func TestPlacementPlacementMapMalformedMap(t *testing.T) {
+	_, err := CreateVindex("placement", "placement", map[string]string{
+		"placement_map":             "xyz",
+		"placement_prefix_bytes":    "1",
+		"placement_sub_vindex_type": "hash",
+	})
+	assert.EqualError(t, err, "malformed placement_map; entry: xyz; expected key:value")
+}
+
+func TestPlacementPlacementMapMissingKey(t *testing.T) {
+	_, err := CreateVindex("placement", "placement", map[string]string{
+		"placement_map":             "abc:1,:2,ghi:3",
+		"placement_prefix_bytes":    "1",
+		"placement_sub_vindex_type": "hash",
+	})
+	assert.EqualError(t, err, "malformed placement_map; entry: :2; unexpected empty key")
+}
+
+func TestPlacementPlacementMapMissingValue(t *testing.T) {
+	_, err := CreateVindex("placement", "placement", map[string]string{
+		"placement_map":             "abc:1,def:,ghi:3",
+		"placement_prefix_bytes":    "1",
+		"placement_sub_vindex_type": "hash",
+	})
+	assert.EqualError(t, err, "malformed placement_map; entry: def:; unexpected empty value")
+}
+
+func TestPlacementPlacementMapMalformedValue(t *testing.T) {
+	_, err := CreateVindex("placement", "placement", map[string]string{
+		"placement_map":             "abc:xyz",
+		"placement_prefix_bytes":    "1",
+		"placement_sub_vindex_type": "hash",
+	})
+	assert.EqualError(t, err, "malformed placement_map; entry: abc:xyz; strconv.ParseUint: parsing \"xyz\": invalid syntax")
+}
+
+func TestPlacementPrefixBytesMissing(t *testing.T) {
+	_, err := CreateVindex("placement", "placement", map[string]string{
+		"placement_map":             "foo:1,bar:2",
+		"placement_sub_vindex_type": "hash",
+	})
+	assert.EqualError(t, err, "missing params: placement_prefix_bytes")
+}
+
+func TestPlacementPrefixBytesTooLow(t *testing.T) {
+	_, err := CreateVindex("placement", "placement", map[string]string{
+		"placement_map":             "foo:1,bar:2",
+		"placement_prefix_bytes":    "0",
+		"placement_sub_vindex_type": "hash",
+	})
+	assert.EqualError(t, err, "invalid placement_prefix_bytes: 0; expected integer between 1 and 7")
+}
+
+func TestPlacementPrefixBytesTooHigh(t *testing.T) {
+	_, err := CreateVindex("placement", "placement", map[string]string{
+		"placement_map":             "foo:1,bar:2",
+		"placement_prefix_bytes":    "17",
+		"placement_sub_vindex_type": "hash",
+	})
+	assert.EqualError(t, err, "invalid placement_prefix_bytes: 17; expected integer between 1 and 7")
+}
+
+func TestPlacementSubVindexTypeMissing(t *testing.T) {
+	_, err := CreateVindex("placement", "placement", map[string]string{
+		"placement_map":          "foo:1,bar:2",
+		"placement_prefix_bytes": "1",
+	})
+	assert.EqualError(t, err, "missing params: placement_sub_vindex_type")
+}
+
+func TestPlacementSubVindexTypeIncorrect(t *testing.T) {
+	_, err := CreateVindex("placement", "placement", map[string]string{
+		"placement_map":             "foo:1,bar:2",
+		"placement_prefix_bytes":    "1",
+		"placement_sub_vindex_type": "doesnotexist",
+	})
+	assert.EqualError(t, err, "invalid placement_sub_vindex_type: vindexType \"doesnotexist\" not found")
+}
+
+func TestPlacementMapSqlTypeVarChar(t *testing.T) {
+	vindex, err := CreateVindex("placement", "placement", map[string]string{
+		"table":                     "t",
+		"from":                      "f1,f2",
+		"to":                        "toc",
+		"placement_prefix_bytes":    "1",
+		"placement_map":             "foo:1,bar:2",
+		"placement_sub_vindex_type": "xxhash",
+	})
+	assert.NoError(t, err)
+	actualDestinations, err := vindex.(MultiColumn).Map(context.Background(), nil, [][]sqltypes.Value{{
+		sqltypes.NewVarChar("foo"), sqltypes.NewVarChar("hello world"),
+	}, {
+		sqltypes.NewVarChar("bar"), sqltypes.NewVarChar("hello world"),
+	}, {
+		sqltypes.NewVarChar("xyz"), sqltypes.NewVarChar("hello world"),
+	}})
+	assert.NoError(t, err)
+
+	expectedDestinations := []key.Destination{
+		key.DestinationKeyspaceID{0x01, 0x68, 0x69, 0x1e, 0xb2, 0x34, 0x67, 0xab},
+		key.DestinationKeyspaceID{0x02, 0x68, 0x69, 0x1e, 0xb2, 0x34, 0x67, 0xab},
+		key.DestinationNone{},
+	}
+	assert.Equal(t, expectedDestinations, actualDestinations)
+}
+
+func TestPlacementMapSqlTypeInt64(t *testing.T) {
+	vindex, err := CreateVindex("placement", "placement", map[string]string{
+		"table":                     "t",
+		"from":                      "f1,f2",
+		"to":                        "toc",
+		"placement_prefix_bytes":    "1",
+		"placement_map":             "foo:1,bar:2",
+		"placement_sub_vindex_type": "xxhash",
+	})
+	assert.NoError(t, err)
+	actualDestinations, err := vindex.(MultiColumn).Map(context.Background(), nil, [][]sqltypes.Value{{
+		sqltypes.NewVarChar("foo"), sqltypes.NewInt64(1),
+	}, {
+		sqltypes.NewVarChar("bar"), sqltypes.NewInt64(1),
+	}, {
+		sqltypes.NewVarChar("xyz"), sqltypes.NewInt64(1),
+	}})
+	assert.NoError(t, err)
+
+	expectedDestinations := []key.Destination{
+		key.DestinationKeyspaceID{0x01, 0xd4, 0x64, 0x05, 0x36, 0x76, 0x12, 0xb4},
+		key.DestinationKeyspaceID{0x02, 0xd4, 0x64, 0x05, 0x36, 0x76, 0x12, 0xb4},
+		key.DestinationNone{},
+	}
+	assert.Equal(t, expectedDestinations, actualDestinations)
+}
+
+func TestPlacementMapWithHexValues(t *testing.T) {
+	vindex, err := CreateVindex("placement", "placement", map[string]string{
+		"table":                     "t",
+		"from":                      "f1,f2",
+		"to":                        "toc",
+		"placement_prefix_bytes":    "1",
+		"placement_map":             "foo:0x01,bar:0x02",
+		"placement_sub_vindex_type": "xxhash",
+	})
+	assert.NoError(t, err)
+	actualDestinations, err := vindex.(MultiColumn).Map(context.Background(), nil, [][]sqltypes.Value{{
+		sqltypes.NewVarChar("foo"), sqltypes.NewInt64(1),
+	}, {
+		sqltypes.NewVarChar("bar"), sqltypes.NewInt64(1),
+	}, {
+		sqltypes.NewVarChar("xyz"), sqltypes.NewInt64(1),
+	}})
+	assert.NoError(t, err)
+
+	expectedDestinations := []key.Destination{
+		key.DestinationKeyspaceID{0x01, 0xd4, 0x64, 0x05, 0x36, 0x76, 0x12, 0xb4},
+		key.DestinationKeyspaceID{0x02, 0xd4, 0x64, 0x05, 0x36, 0x76, 0x12, 0xb4},
+		key.DestinationNone{},
+	}
+	assert.Equal(t, expectedDestinations, actualDestinations)
+}
+
+func TestPlacementMapMultiplePrefixBytes(t *testing.T) {
+	vindex, err := CreateVindex("placement", "placement", map[string]string{
+		"table":                     "t",
+		"from":                      "f1,f2",
+		"to":                        "toc",
+		"placement_prefix_bytes":    "4",
+		"placement_map":             "foo:1,bar:2",
+		"placement_sub_vindex_type": "xxhash",
+	})
+	assert.NoError(t, err)
+	actualDestinations, err := vindex.(MultiColumn).Map(context.Background(), nil, [][]sqltypes.Value{{
+		sqltypes.NewVarChar("foo"), sqltypes.NewInt64(1),
+	}, {
+		sqltypes.NewVarChar("bar"), sqltypes.NewInt64(1),
+	}, {
+		sqltypes.NewVarChar("xyz"), sqltypes.NewInt64(1),
+	}})
+	assert.NoError(t, err)
+
+	expectedDestinations := []key.Destination{
+		key.DestinationKeyspaceID{0x00, 0x00, 0x00, 0x01, 0xd4, 0x64, 0x05, 0x36},
+		key.DestinationKeyspaceID{0x00, 0x00, 0x00, 0x02, 0xd4, 0x64, 0x05, 0x36},
+		key.DestinationNone{},
+	}
+	assert.Equal(t, expectedDestinations, actualDestinations)
+}
+
+func TestPlacementSubVindexNumeric(t *testing.T) {
+	vindex, err := CreateVindex("placement", "placement", map[string]string{
+		"table":                     "t",
+		"from":                      "f1,f2",
+		"to":                        "toc",
+		"placement_prefix_bytes":    "1",
+		"placement_map":             "foo:1,bar:2",
+		"placement_sub_vindex_type": "numeric",
+	})
+	assert.NoError(t, err)
+	actualDestinations, err := vindex.(MultiColumn).Map(context.Background(), nil, [][]sqltypes.Value{{
+		sqltypes.NewVarChar("foo"), sqltypes.NewInt64(0x01234567deadbeef),
+	}, {
+		sqltypes.NewVarChar("bar"), sqltypes.NewInt64(0x01234567deadbeef),
+	}, {
+		sqltypes.NewVarChar("xyz"), sqltypes.NewInt64(0x01234567deadbeef),
+	}})
+	assert.NoError(t, err)
+
+	expectedDestinations := []key.Destination{
+		key.DestinationKeyspaceID{0x01, 0x01, 0x23, 0x45, 0x67, 0xde, 0xad, 0xbe},
+		key.DestinationKeyspaceID{0x02, 0x01, 0x23, 0x45, 0x67, 0xde, 0xad, 0xbe},
+		key.DestinationNone{},
+	}
+	assert.Equal(t, expectedDestinations, actualDestinations)
+}


### PR DESCRIPTION
Signed-off-by: Jeremy Cole <jeremy.cole@shopify.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Add a `placement` Vindex type for use in regional sharding.

A Vindex which uses a mapping lookup table `placement_map` to set the first `placement_prefix_bytes` of the Keyspace ID and another Vindex type `placement_sub_vindex_type` (which must support Hashing) as a sub-Vindex to set the rest. This is suitable for regional sharding (like `region_json` or `region_experimental`) but does not require a mapping file, and can support non-integer types for the sharding column.

All parameters are prefixed with `placement_` to avoid conflict, because the `params` map is passed to the sub-Vindex as well.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
