### PR TITLE
Escape Sequence identifiers in VSchema when necessary

### DIFF
--- a/go/vt/topotools/vschema_ddl.go
+++ b/go/vt/topotools/vschema_ddl.go
@@ -17,7 +17,6 @@ limitations under the License.
 package topotools
 
 import (
-	"fmt"
 	"reflect"
 
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -226,15 +225,9 @@ func ApplyVSchemaDDL(ksName string, ks *vschemapb.Keyspace, alterVschema *sqlpar
 			return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "vschema already contains auto inc %v on table %s in keyspace %s", table.AutoIncrement, name, ksName)
 		}
 
-		sequence := alterVschema.AutoIncSpec.Sequence
-		sequenceFqn := sequence.Name.String()
-		if sequence.Qualifier.String() != "" {
-			sequenceFqn = fmt.Sprintf("%s.%s", sequence.Qualifier.String(), sequenceFqn)
-		}
-
 		table.AutoIncrement = &vschemapb.AutoIncrement{
 			Column:   alterVschema.AutoIncSpec.Column.String(),
-			Sequence: sequenceFqn,
+			Sequence: sqlparser.String(alterVschema.AutoIncSpec.Sequence),
 		}
 
 		return ks, nil

--- a/go/vt/vtgate/executor_vschema_ddl_test.go
+++ b/go/vt/vtgate/executor_vschema_ddl_test.go
@@ -373,13 +373,13 @@ func TestExecutorAddSequenceDDL(t *testing.T) {
 	}
 	time.Sleep(10 * time.Millisecond)
 
-	stmt = "alter vschema on test_table add auto_increment id using test_seq"
+	stmt = "alter vschema on test_table add auto_increment id using `db-name`.`test_seq`"
 	if _, err = executor.Execute(context.Background(), "TestExecute", session, stmt, nil); err != nil {
 		t.Error(err)
 	}
 	time.Sleep(10 * time.Millisecond)
 
-	wantAutoInc := &vschemapb.AutoIncrement{Column: "id", Sequence: "test_seq"}
+	wantAutoInc := &vschemapb.AutoIncrement{Column: "id", Sequence: "`db-name`.test_seq"}
 	gotAutoInc := executor.vm.GetCurrentSrvVschema().Keyspaces[ksSharded].Tables["test_table"].AutoIncrement
 
 	if !reflect.DeepEqual(wantAutoInc, gotAutoInc) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
