### PR TITLE
Fixes the `SwitchTraffic` bug that wasn't respecting `--dry_run` for readonly and replica tablets during a resharding event

### DIFF
--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -397,7 +397,7 @@ func (wr *Wrangler) SwitchReads(ctx context.Context, targetKeyspace, workflowNam
 		return sw.logs(), nil
 	}
 	wr.Logger().Infof("About to switchShardReads: %+v, %+v, %+v", cells, servedTypes, direction)
-	if err := ts.switchShardReads(ctx, cells, servedTypes, direction); err != nil {
+	if err := sw.switchShardReads(ctx, cells, servedTypes, direction); err != nil {
 		ts.Logger().Errorf("switchShardReads failed: %v", err)
 		return nil, err
 	}


### PR DESCRIPTION
ref: https://github.com/Shopify/vitess-project/issues/431

Fixes the `SwitchTraffic` bug that wasn't respecting `--dry_run` for readonly and replica tablets during a resharding event. More [details specifically in this comment](https://github.com/Shopify/vitess-project/issues/431#issuecomment-1523618883).