### PR TITLE
Generate CachedSize function for Placement vindex

### DIFF
--- a/go/vt/vtgate/vindexes/cached_size.go
+++ b/go/vt/vtgate/vindexes/cached_size.go
@@ -348,6 +348,42 @@ func (cached *NumericStaticMap) CachedSize(alloc bool) int64 {
 	}
 	return size
 }
+
+//go:nocheckptr
+func (cached *Placement) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(80)
+	}
+	// field name string
+	size += hack.RuntimeAllocSize(int64(len(cached.name)))
+	// field placementMap vitess.io/vitess/go/vt/vtgate/vindexes.PlacementMap
+	if cached.placementMap != nil {
+		size += int64(48)
+		hmap := reflect.ValueOf(cached.placementMap)
+		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
+		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
+		size += hack.RuntimeAllocSize(int64(numOldBuckets * 208))
+		if len(cached.placementMap) > 0 || numBuckets > 1 {
+			size += hack.RuntimeAllocSize(int64(numBuckets * 208))
+		}
+		for k := range cached.placementMap {
+			size += hack.RuntimeAllocSize(int64(len(k)))
+		}
+	}
+	// field subVindex vitess.io/vitess/go/vt/vtgate/vindexes.Vindex
+	if cc, ok := cached.subVindex.(cachedObject); ok {
+		size += cc.CachedSize(true)
+	}
+	// field subVindexType string
+	size += hack.RuntimeAllocSize(int64(len(cached.subVindexType)))
+	// field subVindexName string
+	size += hack.RuntimeAllocSize(int64(len(cached.subVindexName)))
+	return size
+}
 func (cached *RegionExperimental) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)


### PR DESCRIPTION
Generated via `make sizegen`

Fixes this [Static Code Checks Etc workflow](https://github.com/Shopify/vitess/blob/v15.0.3-shopify-3/.github/workflows/static_checks_etc.yml) failure:
![image](https://github.com/Shopify/vitess/assets/3218923/512f793f-08ba-498e-97c1-c112ff2a2fa8)

**Impact**
Based on https://github.com/vitessio/vitess/pull/7387 and https://github.com/vitessio/vitess/pull/7439, it looks like the `CachedSize` function is used to calculate how much memory a struct requires, and that is used to determine total cache size in memory, trigger eviction, and determine whether a struct should be cached at all. This change makes that calculation slightly more accurate, so I don't expect it to have a noticeable impact.

**Why didn't we catch this sooner?**
The Static Code Checks Etc workflow is skipped under [certain conditions](https://github.com/Shopify/vitess/blob/v15.0.3-shopify-3/.github/workflows/static_checks_etc.yml#L13-L21). Opening a PR will cause the workflow to run. I suspect we simply didn't notice the workflow failure in the original Placement vindex PR: https://github.com/Shopify/vitess/pull/77