### PR TITLE
Custom jwt http ACL policy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -116,7 +116,9 @@ require (
 )
 
 require (
+	github.com/MicahParks/keyfunc/v2 v2.1.0
 	github.com/bndr/gotabulate v1.1.2
+	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/hashicorp/go-version v1.6.0
 	golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb
 	modernc.org/sqlite v1.20.3

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/HdrHistogram/hdrhistogram-go v0.9.0/go.mod h1:nxrse8/Tzg2tg3DZcZjm6qE
 github.com/Masterminds/glide v0.13.2/go.mod h1:STyF5vcenH/rUqTEv+/hBXlSTo7KYwg2oc2f4tzPWic=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/vcs v1.13.0/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
+github.com/MicahParks/keyfunc/v2 v2.1.0 h1:6ZXKb9Rp6qp1bDbJefnG7cTH8yMN1IC/4nf+GVjO99k=
+github.com/MicahParks/keyfunc/v2 v2.1.0/go.mod h1:rW42fi+xgLJ2FRRXAfNx9ZA8WpD4OeE/yHVMteCkw9k=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/goquery v1.5.1 h1:PSPBGne8NIUWw+/7vFBV+kG2J/5MOjbzc7154OaKCSE=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
@@ -281,6 +283,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
+github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/go/acl/shopify_jwt_policy.go
+++ b/go/acl/shopify_jwt_policy.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acl
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	keyfunc "github.com/MicahParks/keyfunc/v2"
+	jwt "github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	SHOPIFY_JWT             = "shopify_jwt"
+	SHOPIFY_COOKIE_NAME_ENV = "JWT_COOKIE_NAME"
+	SHOPIFY_JWKS_URL_ENV    = "JWKS_URL"
+)
+
+var errDenyShopifyJwt = errors.New("not allowed: shopify_jwt security_policy enforced")
+
+func jwksRequestFactory(ctx context.Context, url string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, bytes.NewReader(nil))
+
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}
+
+type shopifyJwt struct{}
+
+func validateJWT(tokenString string, jwksURL string) (bool, error) {
+	// Fetch the JWKS from the provided URL
+	jwks, err := keyfunc.Get(jwksURL, keyfunc.Options{
+		RequestFactory: jwksRequestFactory,
+	})
+
+	defer jwks.EndBackground()
+
+	if err != nil {
+		return false, err
+	}
+
+	// Parse and validate the JWT token
+	token, err := jwt.Parse(tokenString, jwks.Keyfunc)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse JWT token: %v", err)
+	}
+
+	if token.Valid {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// CheckAccessActor disallows actor access not verified by shopifyJwt
+func (shopifyJwt) CheckAccessActor(actor, role string) error {
+	switch role {
+	case SHOPIFY_JWT:
+		return nil
+	default:
+		return errDenyShopifyJwt
+	}
+}
+
+// CheckAccessHTTP disallows HTTP access not verified by shopifyJwt
+func (shopifyJwt) CheckAccessHTTP(req *http.Request, role string) error {
+	switch role {
+	case SHOPIFY_JWT:
+		jwtCookie, err := req.Cookie(os.Getenv("SHOPIFY_COOKIE_NAME_ENV"))
+
+		if err != nil {
+			log.Printf("failed to get jwt token from cookie: %s", err)
+			return err
+		}
+
+		_, err = validateJWT(jwtCookie.Value, os.Getenv(SHOPIFY_JWKS_URL_ENV))
+
+		if err != nil {
+			log.Printf("invalid JWT token provided: %s", err)
+			return err
+		}
+
+		return nil
+	default:
+		return errDenyShopifyJwt
+	}
+}
+
+func init() {
+	RegisterPolicy(SHOPIFY_JWT, shopifyJwt{})
+}

--- a/go/acl/shopify_jwt_policy.go
+++ b/go/acl/shopify_jwt_policy.go
@@ -19,23 +19,45 @@ package acl
 import (
 	"bytes"
 	"context"
+	b64 "encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 
 	keyfunc "github.com/MicahParks/keyfunc/v2"
 	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 const (
-	SHOPIFY_JWT             = "shopify_jwt"
-	SHOPIFY_COOKIE_NAME_ENV = "JWT_COOKIE_NAME"
-	SHOPIFY_JWKS_URL_ENV    = "JWKS_URL"
+	SHOPIFY_JWT                = "shopify_jwt"
+	SHOPIFY_JWT_HEADER_ENV     = "SHOPIFY_JWT_HEADER"
+	SHOPIFY_JWKS_URL_ENV       = "SHOPIFY_JWKS_URL"
+	SHOPIFY_USER_ID_HEADER_ENV = "SHOPIFY_USER_ID_HEADER"
+	SHOPIFY_AUTHZ_URL_ENV      = "SHOPIFY_AUTHZ_URL"
+	SHOPIFY_AUTHZ_GROUPS_ENV   = "SHOPIFY_AUTHZ_GROUPS"
+	SHOPIFY_AUTHZ_USERNAME_ENV = "SHOPIFY_AUTHZ_USERNAME"
+	SHOPIFY_AUTHZ_PASSWORD_ENV = "SHOPIFY_AUTHZ_PASSWORD"
 )
 
 var errDenyShopifyJwt = errors.New("not allowed: shopify_jwt security_policy enforced")
+
+type membership struct {
+	Group  string
+	Member bool
+}
+
+type shopifyAuthzData struct {
+	Memberships []membership
+}
+
+type shopifyAuthzResponse struct {
+	Data shopifyAuthzData
+}
 
 func jwksRequestFactory(ctx context.Context, url string) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, bytes.NewReader(nil))
@@ -75,6 +97,76 @@ func validateJWT(tokenString string, jwksURL string) (bool, error) {
 	return false, nil
 }
 
+func buildAuth(username string, password string) string {
+	return fmt.Sprintf("Basic %s", b64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password))))
+}
+
+func authorizeUser(userId int) (bool, error) {
+	url := os.Getenv(SHOPIFY_AUTHZ_URL_ENV)
+
+	var groups string
+
+	for _, group := range strings.Split(os.Getenv(SHOPIFY_AUTHZ_GROUPS_ENV), ",") {
+		groups += fmt.Sprintf("\"%s\",", group)
+	}
+
+	query := map[string]string{
+		"query": fmt.Sprintf(`
+			{
+				memberships(
+					userEmployeeId: %d
+					groups: [%s]
+				) {
+					member
+					group
+				}
+			}
+		`, userId, groups),
+	}
+
+	queryJson, err := json.Marshal(query)
+
+	if err != nil {
+		return false, err
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(queryJson))
+
+	if err != nil {
+		return false, err
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Authorization", buildAuth(os.Getenv(SHOPIFY_AUTHZ_USERNAME_ENV), os.Getenv(SHOPIFY_AUTHZ_PASSWORD_ENV)))
+
+	client := &http.Client{}
+	res, err := client.Do(req)
+
+	if err != nil {
+		return false, err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("failed to authorize user. status: %s", res.Status)
+	}
+
+	var jsonRes shopifyAuthzResponse
+	err = json.NewDecoder(res.Body).Decode(&jsonRes)
+	if err != nil {
+		return false, err
+	}
+
+	for _, membership := range jsonRes.Data.Memberships {
+		if membership.Member {
+			return true, nil
+		}
+	}
+
+	return false, fmt.Errorf("user is not a member of any authorized groups")
+}
+
 // CheckAccessActor disallows actor access not verified by shopifyJwt
 func (shopifyJwt) CheckAccessActor(actor, role string) error {
 	switch role {
@@ -89,17 +181,43 @@ func (shopifyJwt) CheckAccessActor(actor, role string) error {
 func (shopifyJwt) CheckAccessHTTP(req *http.Request, role string) error {
 	switch role {
 	case SHOPIFY_JWT:
-		jwtCookie, err := req.Cookie(os.Getenv("SHOPIFY_COOKIE_NAME_ENV"))
+		jwtToken := req.Header.Get(os.Getenv(SHOPIFY_JWT_HEADER_ENV))
 
-		if err != nil {
-			log.Printf("failed to get jwt token from cookie: %s", err)
-			return err
+		if len(jwtToken) < 1 {
+			log.Println("failed to get jwt token from header")
+			return errDenyShopifyJwt
 		}
 
-		_, err = validateJWT(jwtCookie.Value, os.Getenv(SHOPIFY_JWKS_URL_ENV))
+		_, err := validateJWT(jwtToken, os.Getenv(SHOPIFY_JWKS_URL_ENV))
 
 		if err != nil {
 			log.Printf("invalid JWT token provided: %s", err)
+			return err
+		}
+
+		userId := req.Header.Get(os.Getenv(SHOPIFY_USER_ID_HEADER_ENV))
+
+		if len(userId) < 1 {
+			log.Println("failed to get user id from header")
+			return errDenyShopifyJwt
+		}
+
+		userIdInt, err := strconv.Atoi(userId)
+
+		if err != nil {
+			log.Printf("failed to convert user id to int: %s", err)
+			return err
+		}
+
+		authorized, err := authorizeUser(userIdInt)
+
+		if err != nil {
+			log.Printf("failed to authorize user ID: %s, %v", userId, err)
+			return err
+		}
+
+		if !authorized {
+			log.Printf("user ID %s is not authorized", userId)
 			return err
 		}
 

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -184,7 +184,7 @@ func (logger *StreamLogger) Name() string {
 // It is safe to register multiple URLs for the same StreamLogger.
 func (logger *StreamLogger) ServeLogs(url string, logf LogFormatter) {
 	http.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
-		if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
+		if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_JWT); err != nil {
 			acl.SendError(w, err)
 			return
 		}

--- a/go/vt/servenv/status.go
+++ b/go/vt/servenv/status.go
@@ -201,7 +201,7 @@ func (sp *statusPage) addStatusSection(banner string, f func() string) {
 }
 
 func (sp *statusPage) statusHandler(w http.ResponseWriter, r *http.Request) {
-	if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
+	if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(w, err)
 		return
 	}
@@ -250,7 +250,7 @@ func (sp *statusPage) reparse(sections []section) (*template.Template, error) {
 // Toggle the block profile rate to/from 100%, unless specific rate is passed in
 func registerDebugBlockProfileRate() {
 	http.HandleFunc("/debug/blockprofilerate", func(w http.ResponseWriter, r *http.Request) {
-		if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
+		if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_JWT); err != nil {
 			acl.SendError(w, err)
 			return
 		}
@@ -280,7 +280,7 @@ func registerDebugBlockProfileRate() {
 // Toggle the mutex profiling fraction to/from 100%, unless specific fraction is passed in
 func registerDebugMutexProfileFraction() {
 	http.HandleFunc("/debug/mutexprofilefraction", func(w http.ResponseWriter, r *http.Request) {
-		if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
+		if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_JWT); err != nil {
 			acl.SendError(w, err)
 			return
 		}

--- a/go/vt/vtctld/debug_health.go
+++ b/go/vt/vtctld/debug_health.go
@@ -30,7 +30,7 @@ import (
 // RegisterDebugHealthHandler register a debug health http endpoint for a vtcld server
 func RegisterDebugHealthHandler(ts *topo.Server) {
 	http.HandleFunc("/debug/health", func(w http.ResponseWriter, r *http.Request) {
-		if err := acl.CheckAccessHTTP(r, acl.MONITORING); err != nil {
+		if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_JWT); err != nil {
 			acl.SendError(w, err)
 			return
 		}

--- a/go/vt/vtgate/debugenv.go
+++ b/go/vt/vtgate/debugenv.go
@@ -88,7 +88,11 @@ type envValue struct {
 }
 
 func debugEnvHandler(vtg *VTGate, w http.ResponseWriter, r *http.Request) {
-	if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
+	// if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
+	// 	acl.SendError(w, err)
+	// 	return
+	// }
+	if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(w, err)
 		return
 	}

--- a/go/vt/vtgate/debugenv.go
+++ b/go/vt/vtgate/debugenv.go
@@ -88,10 +88,6 @@ type envValue struct {
 }
 
 func debugEnvHandler(vtg *VTGate, w http.ResponseWriter, r *http.Request) {
-	// if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
-	// 	acl.SendError(w, err)
-	// 	return
-	// }
 	if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(w, err)
 		return

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1104,7 +1104,7 @@ func (e *Executor) debugCacheEntries() (items []cacheItem) {
 
 // ServeHTTP shows the current plans in the query cache.
 func (e *Executor) ServeHTTP(response http.ResponseWriter, request *http.Request) {
-	if err := acl.CheckAccessHTTP(request, acl.DEBUGGING); err != nil {
+	if err := acl.CheckAccessHTTP(request, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(response, err)
 		return
 	}

--- a/go/vt/vtgate/querylogz.go
+++ b/go/vt/vtgate/querylogz.go
@@ -87,7 +87,7 @@ var (
 // querylogzHandler serves a human readable snapshot of the
 // current query log.
 func querylogzHandler(ch chan any, w http.ResponseWriter, r *http.Request) {
-	if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
+	if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(w, err)
 		return
 	}

--- a/go/vt/vtgate/queryz.go
+++ b/go/vt/vtgate/queryz.go
@@ -127,7 +127,7 @@ func (s *queryzSorter) Swap(i, j int)      { s.rows[i], s.rows[j] = s.rows[j], s
 func (s *queryzSorter) Less(i, j int) bool { return s.less(s.rows[i], s.rows[j]) }
 
 func queryzHandler(e *Executor, w http.ResponseWriter, r *http.Request) {
-	if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
+	if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(w, err)
 		return
 	}

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -389,7 +389,7 @@ func (vtg *VTGate) registerDebugEnvHandler() {
 
 func (vtg *VTGate) registerDebugHealthHandler() {
 	http.HandleFunc("/debug/health", func(w http.ResponseWriter, r *http.Request) {
-		if err := acl.CheckAccessHTTP(r, acl.MONITORING); err != nil {
+		if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_JWT); err != nil {
 			acl.SendError(w, err)
 			return
 		}

--- a/go/vt/vttablet/tabletserver/debugenv.go
+++ b/go/vt/vttablet/tabletserver/debugenv.go
@@ -64,7 +64,11 @@ func addVar[T any](vars []envValue, name string, f func() T) []envValue {
 }
 
 func debugEnvHandler(tsv *TabletServer, w http.ResponseWriter, r *http.Request) {
-	if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
+	// if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
+	// 	acl.SendError(w, err)
+	// 	return
+	// }
+	if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(w, err)
 		return
 	}

--- a/go/vt/vttablet/tabletserver/debugenv.go
+++ b/go/vt/vttablet/tabletserver/debugenv.go
@@ -64,10 +64,6 @@ func addVar[T any](vars []envValue, name string, f func() T) []envValue {
 }
 
 func debugEnvHandler(tsv *TabletServer, w http.ResponseWriter, r *http.Request) {
-	// if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
-	// 	acl.SendError(w, err)
-	// 	return
-	// }
 	if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(w, err)
 		return

--- a/go/vt/vttablet/tabletserver/livequeryz.go
+++ b/go/vt/vttablet/tabletserver/livequeryz.go
@@ -55,7 +55,7 @@ var (
 )
 
 func livequeryzHandler(queryLists []*QueryList, w http.ResponseWriter, r *http.Request) {
-	if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
+	if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(w, err)
 		return
 	}

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -517,7 +517,7 @@ type perQueryStats struct {
 }
 
 func (qe *QueryEngine) handleHTTPQueryPlans(response http.ResponseWriter, request *http.Request) {
-	if err := acl.CheckAccessHTTP(request, acl.DEBUGGING); err != nil {
+	if err := acl.CheckAccessHTTP(request, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(response, err)
 		return
 	}
@@ -537,7 +537,7 @@ func (qe *QueryEngine) handleHTTPQueryPlans(response http.ResponseWriter, reques
 }
 
 func (qe *QueryEngine) handleHTTPQueryStats(response http.ResponseWriter, request *http.Request) {
-	if err := acl.CheckAccessHTTP(request, acl.DEBUGGING); err != nil {
+	if err := acl.CheckAccessHTTP(request, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(response, err)
 		return
 	}
@@ -563,7 +563,7 @@ func (qe *QueryEngine) handleHTTPQueryStats(response http.ResponseWriter, reques
 }
 
 func (qe *QueryEngine) handleHTTPQueryRules(response http.ResponseWriter, request *http.Request) {
-	if err := acl.CheckAccessHTTP(request, acl.DEBUGGING); err != nil {
+	if err := acl.CheckAccessHTTP(request, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(response, err)
 		return
 	}
@@ -579,7 +579,7 @@ func (qe *QueryEngine) handleHTTPQueryRules(response http.ResponseWriter, reques
 }
 
 func (qe *QueryEngine) handleHTTPAclJSON(response http.ResponseWriter, request *http.Request) {
-	if err := acl.CheckAccessHTTP(request, acl.DEBUGGING); err != nil {
+	if err := acl.CheckAccessHTTP(request, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(response, err)
 		return
 	}
@@ -601,11 +601,7 @@ func (qe *QueryEngine) handleHTTPAclJSON(response http.ResponseWriter, request *
 
 // ServeHTTP lists the most recent, cached queries and their count.
 func (qe *QueryEngine) handleHTTPConsolidations(response http.ResponseWriter, request *http.Request) {
-	if err := acl.CheckAccessHTTP(request, acl.DEBUGGING); err != nil {
-		acl.SendError(response, err)
-		return
-	}
-	if err := acl.CheckAccessHTTP(request, acl.DEBUGGING); err != nil {
+	if err := acl.CheckAccessHTTP(request, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(response, err)
 		return
 	}

--- a/go/vt/vttablet/tabletserver/querylogz.go
+++ b/go/vt/vttablet/tabletserver/querylogz.go
@@ -98,7 +98,7 @@ func init() {
 // querylogzHandler serves a human readable snapshot of the
 // current query log.
 func querylogzHandler(ch chan any, w http.ResponseWriter, r *http.Request) {
-	if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
+	if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(w, err)
 		return
 	}

--- a/go/vt/vttablet/tabletserver/queryz.go
+++ b/go/vt/vttablet/tabletserver/queryz.go
@@ -137,7 +137,7 @@ func (s *queryzSorter) Swap(i, j int)      { s.rows[i], s.rows[j] = s.rows[j], s
 func (s *queryzSorter) Less(i, j int) bool { return s.less(s.rows[i], s.rows[j]) }
 
 func queryzHandler(qe *QueryEngine, w http.ResponseWriter, r *http.Request) {
-	if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
+	if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(w, err)
 		return
 	}

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -621,7 +621,7 @@ func (se *Engine) GetConnection(ctx context.Context) (*connpool.DBConn, error) {
 }
 
 func (se *Engine) handleDebugSchema(response http.ResponseWriter, request *http.Request) {
-	if err := acl.CheckAccessHTTP(request, acl.DEBUGGING); err != nil {
+	if err := acl.CheckAccessHTTP(request, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(response, err)
 		return
 	}

--- a/go/vt/vttablet/tabletserver/schema/schemaz.go
+++ b/go/vt/vttablet/tabletserver/schema/schemaz.go
@@ -65,7 +65,7 @@ func (sorter *schemazSorter) Less(i, j int) bool {
 }
 
 func schemazHandler(tables map[string]*Table, w http.ResponseWriter, r *http.Request) {
-	if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
+	if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(w, err)
 		return
 	}

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1713,7 +1713,7 @@ func (tsv *TabletServer) healthzHandler(w http.ResponseWriter, r *http.Request) 
 // Returns ok if a query can go all the way to database and back
 func (tsv *TabletServer) registerDebugHealthHandler() {
 	tsv.exporter.HandleFunc("/debug/health", func(w http.ResponseWriter, r *http.Request) {
-		if err := acl.CheckAccessHTTP(r, acl.MONITORING); err != nil {
+		if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_JWT); err != nil {
 			acl.SendError(w, err)
 			return
 		}

--- a/go/vt/vttablet/tabletserver/twopcz.go
+++ b/go/vt/vttablet/tabletserver/twopcz.go
@@ -130,7 +130,7 @@ var (
 )
 
 func twopczHandler(txe *TxExecutor, w http.ResponseWriter, r *http.Request) {
-	if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
+	if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(w, err)
 		return
 	}

--- a/go/vt/vttablet/tabletserver/txlogz.go
+++ b/go/vt/vttablet/tabletserver/txlogz.go
@@ -81,7 +81,7 @@ func init() {
 // timeout: the txlogz will keep dumping transactions until timeout
 // limit: txlogz will keep dumping transactions until it hits the limit
 func txlogzHandler(w http.ResponseWriter, req *http.Request) {
-	if err := acl.CheckAccessHTTP(req, acl.DEBUGGING); err != nil {
+	if err := acl.CheckAccessHTTP(req, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(w, err)
 		return
 	}

--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
@@ -338,7 +338,7 @@ func (txs *TxSerializer) ServeHTTP(response http.ResponseWriter, request *http.R
 		return
 	}
 
-	if err := acl.CheckAccessHTTP(request, acl.DEBUGGING); err != nil {
+	if err := acl.CheckAccessHTTP(request, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(response, err)
 		return
 	}

--- a/go/vt/vttablet/tabletserver/vstreamer/engine.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine.go
@@ -313,7 +313,7 @@ func (vse *Engine) StreamResults(ctx context.Context, query string, send func(*b
 
 // ServeHTTP shows the current VSchema.
 func (vse *Engine) ServeHTTP(response http.ResponseWriter, request *http.Request) {
-	if err := acl.CheckAccessHTTP(request, acl.DEBUGGING); err != nil {
+	if err := acl.CheckAccessHTTP(request, acl.SHOPIFY_JWT); err != nil {
 		acl.SendError(response, err)
 		return
 	}


### PR DESCRIPTION
## What

Adds a custom shopify JWT http ACL policy. It works by checking for a JWT token from header in the request and verifying that it's a valid JWT generated by Shopify. It also adds a configurable authorization service that validates a Shopify employee belongs to a declarative list of groups.

## Manual testing

**Verify it denies access if no token**

```
spin@localhost:~/src/github.com/Shopify/vitess$ curl localhost:15100/debug/env
Access denied: not allowed: shopify_jwt security_policy enforced
```

**Verify it works with a valid token**

```
spin@localhost:~/src/github.com/Shopify/curl -H 'TOKEN_HEADER_HERE '"$TOKEN"'' localhost:15100/debug/env
<!DOCTYPE html>
        <h3>Internal Variables</h3>

        <table class="gridtable">

        <thead><tr>
                <th>Variable Name</th>
                <th>Value</th>
                <th>Action</th>
        </tr></thead>

        <tr><form method="POST">
                <td>PoolSize</td>
                <td>
                        <input type="hidden" name="varname" value="PoolSize"></input>
                        <input type="text" name="value" value="16"></input>
... # cut off for brevity
```

**Verify a malformed JWT denies access**

```
spin@localhost:~/src/github.com/Shopify/vitess$ curl -H 'TOKEN_HEADER_HERE foobar' localhost:15100/debug/env
Access denied: failed to parse JWT token: token is malformed: token contains an invalid number of segments
```

**Verify an invalid JWT denies access**

```
spin@localhost:~/src/github.com/Shopify/vitess$ curl -H 'TOKEN_HEADER_HERE '"$BAD_TOKEN"'' localhost:15100/debug/env
Access denied: failed to parse JWT token: token is unverifiable: error while executing keyfunc: the JWT has an invalid kid: could not find kid in JWT header
```
