### PR TITLE
[DRAFT] http basic auth acl policy

### DIFF
--- a/go/acl/shopify_basic_auth_policy.go
+++ b/go/acl/shopify_basic_auth_policy.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acl
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const (
+	SHOPIFY_BASIC_AUTH          = "shopify_basic_auth"
+	shopifyBasicAuthUsernameEnv = "SHOPIFY_BASIC_AUTH_USERNAME"
+	shopifyBasicAuthPasswordEnv = "SHOPIFY_BASIC_AUTH_PASSWORD"
+)
+
+var errDenyShopifyBasicAuth = errors.New("not allowed: shopify_basic_auth security_policy enforced")
+
+// The http API does not support https so using basic auth should not be considered secure as it's possible
+// for the credentials to be sent in plain text.
+type shopifyBasicAuth struct{}
+
+func validateBasicAuth(username string, password string) bool {
+	usernameEnv := strings.TrimSpace(os.Getenv(shopifyBasicAuthUsernameEnv))
+	passwordEnv := strings.TrimSpace(os.Getenv(shopifyBasicAuthPasswordEnv))
+
+	return (username == usernameEnv && password == passwordEnv)
+}
+
+// CheckAccessActor disallows actor access not verified by shopifyBasicAuth
+func (shopifyBasicAuth) CheckAccessActor(actor, role string) error {
+	switch role {
+	case SHOPIFY_BASIC_AUTH:
+		return nil
+	default:
+		return errDenyShopifyBasicAuth
+	}
+}
+
+// CheckAccessHTTP disallows HTTP access not verified by shopifyBasicAuth
+func (shopifyBasicAuth) CheckAccessHTTP(req *http.Request, role string) error {
+	switch role {
+	case SHOPIFY_BASIC_AUTH:
+		username, password, ok := req.BasicAuth()
+
+		if !ok {
+			log.Printf("failed to parse basic auth headers")
+			return errDenyShopifyBasicAuth
+		}
+
+		if !validateBasicAuth(strings.TrimSpace(username), strings.TrimSpace(password)) {
+			log.Printf("username and password is invalid: %s:%s", username, password)
+			return errDenyShopifyBasicAuth
+		}
+
+		return nil
+	default:
+		return errDenyShopifyBasicAuth
+	}
+}
+
+func init() {
+	RegisterPolicy(SHOPIFY_BASIC_AUTH, shopifyBasicAuth{})
+}

--- a/go/vt/vtgate/debugenv.go
+++ b/go/vt/vtgate/debugenv.go
@@ -88,7 +88,7 @@ type envValue struct {
 }
 
 func debugEnvHandler(vtg *VTGate, w http.ResponseWriter, r *http.Request) {
-	if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
+	if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_BASIC_AUTH); err != nil {
 		acl.SendError(w, err)
 		return
 	}

--- a/go/vt/vttablet/tabletserver/debugenv.go
+++ b/go/vt/vttablet/tabletserver/debugenv.go
@@ -64,7 +64,7 @@ func addVar[T any](vars []envValue, name string, f func() T) []envValue {
 }
 
 func debugEnvHandler(tsv *TabletServer, w http.ResponseWriter, r *http.Request) {
-	if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
+	if err := acl.CheckAccessHTTP(r, acl.SHOPIFY_BASIC_AUTH); err != nil {
 		acl.SendError(w, err)
 		return
 	}


### PR DESCRIPTION
## What

Adds a custom shopify basic auth http ACL policy. It works by checking for a basic username and password.

## Manual testing

**Set env vars with username and password for testing**

```
~/src/github.com/Shopify/vitess$ export SHOPIFY_BASIC_AUTH_USERNAME=user
~/src/github.com/Shopify/vitess$ export SHOPIFY_BASIC_AUTH_PASSWORD=pass
```

**Verify it denies access if no basic auth creds**

```
~/src/github.com/Shopify/vitess$ curl localhost:15100/debug/env
Access denied: not allowed: shopify_basic_auth security_policy enforced
```

**Verify it works with a valid basic auth creds**

```
~/src/github.com/Shopify/vitess$ curl -u "user:pass" localhost:15100/debug/env
<!DOCTYPE html>
        <style type="text/css">
                        table.gridtable {
                                font-family: verdana,arial,sans-serif;
                                font-size: 11px;
                                border-width: 1px;
                                border-collapse: collapse; table-layout:fixed; overflow: hidden;
                        }
                        table.gridtable th {
                                border-width: 1px;
                                padding: 8px;
                                border-style: solid;
                                background-color: #dedede;
                                white-space: nowrap;
                        }
                        table.gridtable td {
                                border-width: 1px;
                                padding: 5px;
                                border-style: solid;
                        }
                        table.gridtable th {
                                padding-left: 2em;
                                padding-right: 2em;
                        }
        </style>
        <h3>Internal Variables</h3>
... # cut off for brevity
```

**Verify that bad creds are rejected**

```
~/src/github.com/Shopify/vitess$ curl -u "not:valid" localhost:15100/debug/env
Access denied: not allowed: shopify_basic_auth security_policy enforced
```
