### PR TITLE
Improve error messages in tablet gateway when primary tablets are not serving

### DIFF
--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -297,12 +297,12 @@ func (gw *TabletGateway) withRetry(ctx context.Context, target *querypb.Target, 
 			// if we have a keyspace event watcher, check if the reason why our primary is not available is that it's currently being resharded
 			// or if a reparent operation is in progress.
 			if kev := gw.kev; kev != nil {
-				if kev.TargetIsBeingResharded(target) {
-					err = vterrors.Errorf(vtrpcpb.Code_CLUSTER_EVENT, "current keyspace is being resharded")
+				if kev.PrimaryIsNotServing(target) {
+					err = vterrors.Errorf(vtrpcpb.Code_CLUSTER_EVENT, "primary is not serving, there could be a reparent operation in progress")
 					continue
 				}
-				if kev.PrimaryIsNotServing(target) {
-					err = vterrors.Errorf(vtrpcpb.Code_CLUSTER_EVENT, "primary is not serving, there is a reparent operation in progress")
+				if kev.TargetIsBeingResharded(target) {
+					err = vterrors.Errorf(vtrpcpb.Code_CLUSTER_EVENT, "current keyspace is potentially being resharded")
 					continue
 				}
 			}


### PR DESCRIPTION
## Description

The error message returned from the tablet gateway is misleading. For example while a primary was not serving and down Vitess was returning `current keyspace is being resharded` to an application.

I swapped the tablet checks to check if the primary is serving before checking the resharding state.

For example, during a recent incident where a primary mysql was down Vitess was returning `current keyspace is being resharded` error messages back to an application which is very confusing. If we look at the tablet serving state however we can see that the primary is `NOT_SERVING`.

```
ro@admin-web-production(replica)> show vitess_tablets;
+-------------+----------------------------------+-------+------------+-------------+------------------------+---------------+----------------------+
| Cell        | Keyspace                         | Shard | TabletType | State       | Alias                  | Hostname      | PrimaryTermStartTime |
+-------------+----------------------------------+-------+------------+-------------+------------------------+---------------+----------------------+
...
| us-east1    | admin-web-production-sessions-us | -10   | PRIMARY    | NOT_SERVING | us-east1-0000000097    | 247.4.117.26  | 2023-10-11T19:16:00Z |
| us-east1    | admin-web-production-sessions-us | -10   | REPLICA    | NOT_SERVING | us-east1-0000000102    | 247.2.54.58   |                      |
...
+-------------+----------------------------------+-------+------------+-------------+------------------------+---------------+----------------------+
68 rows in set (0.00 sec)
```

With this change we should at least return an error message of `primary is not serving, there could be a reparent operation in progress` which is more valuable than a "potential" resharding message.