### PR TITLE
Refactor and cleanup treatment of keyspace IDs and KeyRange

### DIFF
--- a/go/test/endtoend/keyspace/keyspace_test.go
+++ b/go/test/endtoend/keyspace/keyspace_test.go
@@ -17,13 +17,14 @@ limitations under the License.
 package sequence
 
 import (
-	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"flag"
 	"os"
 	"strings"
 	"testing"
+
+	"vitess.io/vitess/go/vt/key"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -392,8 +393,8 @@ func TestKeyspaceToShardName(t *testing.T) {
 				shardKIDs := shardKIdMap[shardRef.Name]
 				for _, kid := range shardKIDs {
 					id = packKeyspaceID(kid)
-					assert.True(t, bytes.Compare(shardRef.KeyRange.Start, id) <= 0 &&
-						(len(shardRef.KeyRange.End) == 0 || bytes.Compare(id, shardRef.KeyRange.End) < 0))
+					assert.True(t, key.Compare(shardRef.KeyRange.Start, id) <= 0 &&
+						(key.Empty(shardRef.KeyRange.End) || key.Compare(id, shardRef.KeyRange.End) < 0))
 				}
 			}
 		}

--- a/go/vt/discovery/topology_watcher.go
+++ b/go/vt/discovery/topology_watcher.go
@@ -362,7 +362,7 @@ func (fbs *FilterByShard) IsIncluded(tablet *topodata.Tablet) bool {
 			// Exact match (probably a non-sharded keyspace).
 			return true
 		}
-		if kr != nil && c.keyRange != nil && key.KeyRangeIncludes(c.keyRange, kr) {
+		if kr != nil && c.keyRange != nil && key.KeyRangeContainsKeyRange(c.keyRange, kr) {
 			// Our filter's KeyRange includes the provided KeyRange
 			return true
 		}

--- a/go/vt/key/destination.go
+++ b/go/vt/key/destination.go
@@ -128,7 +128,7 @@ func (d DestinationExactKeyRange) String() string {
 
 func processExactKeyRange(allShards []*topodatapb.ShardReference, kr *topodatapb.KeyRange, addShard func(shard string) error) error {
 	sort.SliceStable(allShards, func(i, j int) bool {
-		return KeyRangeStartSmaller(allShards[i].GetKeyRange(), allShards[j].GetKeyRange())
+		return KeyRangeLess(allShards[i].GetKeyRange(), allShards[j].GetKeyRange())
 	})
 
 	shardnum := 0
@@ -139,7 +139,7 @@ func processExactKeyRange(allShards []*topodatapb.ShardReference, kr *topodatapb
 		shardnum++
 	}
 	for shardnum < len(allShards) {
-		if !KeyRangesIntersect(kr, allShards[shardnum].KeyRange) {
+		if !KeyRangeIntersect(kr, allShards[shardnum].KeyRange) {
 			// If we are over the requested keyrange, we
 			// can stop now, we won't find more.
 			break
@@ -215,7 +215,7 @@ func (d DestinationKeyRange) String() string {
 
 func processKeyRange(allShards []*topodatapb.ShardReference, kr *topodatapb.KeyRange, addShard func(shard string) error) error {
 	for _, shard := range allShards {
-		if !KeyRangesIntersect(kr, shard.KeyRange) {
+		if !KeyRangeIntersect(kr, shard.KeyRange) {
 			// We don't need that shard.
 			continue
 		}

--- a/go/vt/key/key.go
+++ b/go/vt/key/key.go
@@ -26,16 +26,18 @@ import (
 	"regexp"
 	"strings"
 
-	"google.golang.org/protobuf/proto"
-
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+)
+
+var (
+	KeyRangePattern = regexp.MustCompile(`^(0|([0-9a-fA-F]{2})*-([0-9a-fA-F]{2})*)$`)
 )
 
 //
 // Uint64Key definitions
 //
 
-// Uint64Key is a uint64 that can be converted into a KeyspaceId.
+// Uint64Key is a uint64 that can be converted into a keyspace id.
 type Uint64Key uint64
 
 func (i Uint64Key) String() string {
@@ -49,9 +51,265 @@ func (i Uint64Key) Bytes() []byte {
 	return buf
 }
 
+// Helper methods for keyspace id values.
+
+// Normalize removes any trailing zero bytes from id. This allows two id values to be compared even if they are
+// different lengths.
+// From a key range perspective, -80 == 00-80 == 0000-8000 == 000000-800000, etc. and they should
+// always be treated the same even if they are different lengths.
+func Normalize(id []byte) []byte {
+	trailingZeroes := 0
+	for i := len(id) - 1; i >= 0 && id[i] == 0x00; i-- {
+		trailingZeroes += 1
+	}
+
+	return id[:len(id)-trailingZeroes]
+}
+
+// Compare compares two keyspace IDs while taking care to normalize them; returns -1 if a<b, 1 if a>b, 0 if equal.
+func Compare(a, b []byte) int {
+	return bytes.Compare(Normalize(a), Normalize(b))
+}
+
+// Less returns true if a is less than b.
+func Less(a, b []byte) bool {
+	return Compare(a, b) < 0
+}
+
+// Equal returns true if a is equal to b.
+func Equal(a, b []byte) bool {
+	return Compare(a, b) == 0
+}
+
+// Empty returns true if id is an empty keyspace ID.
+func Empty(id []byte) bool {
+	return len(Normalize(id)) == 0
+}
+
 //
 // KeyRange helper methods
 //
+
+// KeyRangeAdd adds two adjacent KeyRange values (in any order) into a single value. If the values are not adjacent,
+// it returns false.
+func KeyRangeAdd(a, b *topodatapb.KeyRange) (*topodatapb.KeyRange, bool) {
+	if a == nil || b == nil {
+		return nil, false
+	}
+	if !Empty(a.End) && Equal(a.End, b.Start) {
+		return &topodatapb.KeyRange{Start: a.Start, End: b.End}, true
+	}
+	if !Empty(b.End) && Equal(b.End, a.Start) {
+		return &topodatapb.KeyRange{Start: b.Start, End: a.End}, true
+	}
+	return nil, false
+}
+
+// KeyRangeContains returns true if the provided id is in the keyrange.
+func KeyRangeContains(keyRange *topodatapb.KeyRange, id []byte) bool {
+	if KeyRangeIsComplete(keyRange) {
+		return true
+	}
+	return (Empty(keyRange.Start) || Compare(id, keyRange.Start) >= 0) && (Empty(keyRange.End) || Compare(id, keyRange.End) < 0)
+}
+
+// ParseKeyRangeParts parses a Start and End as hex encoded strings and builds a proto KeyRange.
+func ParseKeyRangeParts(start, end string) (*topodatapb.KeyRange, error) {
+	startKey, err := hex.DecodeString(start)
+	if err != nil {
+		return nil, err
+	}
+	endKey, err := hex.DecodeString(end)
+	if err != nil {
+		return nil, err
+	}
+	return &topodatapb.KeyRange{Start: startKey, End: endKey}, nil
+}
+
+// KeyRangeString formats a topodatapb.KeyRange into a hex encoded string.
+func KeyRangeString(keyRange *topodatapb.KeyRange) string {
+	if KeyRangeIsComplete(keyRange) {
+		return "-"
+	}
+	return hex.EncodeToString(keyRange.Start) + "-" + hex.EncodeToString(keyRange.End)
+}
+
+// KeyRangeStartCompare compares the Start of two KeyRange values using semantics unique to Start values where an
+// empty Start means the *minimum* value; returns -1 if a<b, 1 if a>b, 0 if equal.
+func KeyRangeStartCompare(a, b *topodatapb.KeyRange) int {
+	aIsMinimum := a == nil || Empty(a.Start)
+	bIsMinimum := b == nil || Empty(b.Start)
+
+	if aIsMinimum && bIsMinimum {
+		return 0
+	} else if aIsMinimum {
+		return -1
+	} else if bIsMinimum {
+		return 1
+	}
+
+	return Compare(a.Start, b.Start)
+}
+
+// KeyRangeStartEqual returns true if both KeyRange values have the same Start.
+func KeyRangeStartEqual(a, b *topodatapb.KeyRange) bool {
+	return KeyRangeStartCompare(a, b) == 0
+}
+
+// KeyRangeEndCompare compares the End of two KeyRange values using semantics unique to End values where an
+// empty End means the *maximum* value; returns -1 if a<b, 1 if a>b, 0 if equal.
+func KeyRangeEndCompare(a, b *topodatapb.KeyRange) int {
+	aIsMaximum := a == nil || Empty(a.End)
+	bIsMaximum := b == nil || Empty(b.End)
+
+	if aIsMaximum && bIsMaximum {
+		return 0
+	} else if aIsMaximum {
+		return 1
+	} else if bIsMaximum {
+		return -1
+	}
+
+	return Compare(a.End, b.End)
+}
+
+// KeyRangeEndEqual returns true if both KeyRange values have the same End.
+func KeyRangeEndEqual(a, b *topodatapb.KeyRange) bool {
+	return KeyRangeEndCompare(a, b) == 0
+}
+
+// KeyRangeCompare compares two KeyRange values, taking into account both the Start and End fields and their
+// field-specific comparison logic; returns -1 if a<b, 1 if a>b, 0 if equal. Specifically:
+//
+//   - The Start-specific KeyRangeStartCompare and End-specific KeyRangeEndCompare are used for proper comparison
+//     of an empty value for either Start or End.
+//   - The Start is compared first and End is only compared if Start is equal.
+func KeyRangeCompare(a, b *topodatapb.KeyRange) int {
+	// First, compare the Start field.
+	if v := KeyRangeStartCompare(a, b); v != 0 {
+		// The Start field for a and b differ, and that is enough; return that comparison.
+		return v
+	}
+
+	// The Start field was equal, so compare the End field and return that comparison.
+	return KeyRangeEndCompare(a, b)
+}
+
+// KeyRangeEqual returns true if a and b are equal.
+func KeyRangeEqual(a, b *topodatapb.KeyRange) bool {
+	return KeyRangeCompare(a, b) == 0
+}
+
+// KeyRangeLess returns true if a is less than b.
+func KeyRangeLess(a, b *topodatapb.KeyRange) bool {
+	return KeyRangeCompare(a, b) < 0
+}
+
+// KeyRangeIsComplete returns true if the KeyRange covers the entire keyspace.
+func KeyRangeIsComplete(keyRange *topodatapb.KeyRange) bool {
+	return keyRange == nil || (Empty(keyRange.Start) && Empty(keyRange.End))
+}
+
+// KeyRangeIsPartial returns true if the KeyRange does not cover the entire keyspace.
+func KeyRangeIsPartial(keyRange *topodatapb.KeyRange) bool {
+	return !KeyRangeIsComplete(keyRange)
+}
+
+// KeyRangeContiguous returns true if the End of KeyRange a is equivalent to the Start of the KeyRange b,
+// which means that they are contiguous.
+func KeyRangeContiguous(a, b *topodatapb.KeyRange) bool {
+	if KeyRangeIsComplete(a) || KeyRangeIsComplete(b) {
+		return false // no two KeyRange values can be contiguous if either is the complete range
+	}
+
+	return Equal(a.End, b.Start)
+}
+
+// For more info on the following functions, see:
+//   http://stackoverflow.com/questions/4879315/what-is-a-tidy-algorithm-to-find-overlapping-intervals
+// Two segments defined as (a,b) and (c,d) (with a<b and c<d):
+//   * intersects = (b > c) && (a < d)
+//   * overlap = min(b, d) - max(c, a)
+
+// KeyRangeIntersect returns true if some part of KeyRange a and b overlap, meaning that some keyspace ID values
+// exist in both a and b.
+func KeyRangeIntersect(a, b *topodatapb.KeyRange) bool {
+	if KeyRangeIsComplete(a) || KeyRangeIsComplete(b) {
+		return true // if either KeyRange is complete, there must be an intersection
+	}
+
+	return (Empty(a.End) || Less(b.Start, a.End)) && (Empty(b.End) || Less(a.Start, b.End))
+}
+
+// KeyRangeContainsKeyRange returns true if KeyRange a fully contains KeyRange b.
+func KeyRangeContainsKeyRange(a, b *topodatapb.KeyRange) bool {
+	// If a covers the entire KeyRange, it always contains b.
+	if KeyRangeIsComplete(a) {
+		return true
+	}
+
+	// If b covers the entire KeyRange, a must also cover the entire KeyRange.
+	if KeyRangeIsComplete(b) {
+		return KeyRangeIsComplete(a)
+	}
+
+	// Ensure b.Start >= a.Start and b.End <= a.End.
+	if KeyRangeStartCompare(b, a) >= 0 && KeyRangeEndCompare(b, a) <= 0 {
+		return true
+	}
+
+	return false
+}
+
+// ParseShardingSpec parses a string that describes a sharding
+// specification. a-b-c-d will be parsed as a-b, b-c, c-d. The empty
+// string may serve both as the start and end of the keyspace: -a-b-
+// will be parsed as start-a, a-b, b-end.
+// "0" is treated as "-", to allow us to not have to special-case
+// client code.
+func ParseShardingSpec(spec string) ([]*topodatapb.KeyRange, error) {
+	parts := strings.Split(spec, "-")
+	if len(parts) == 1 {
+		if spec == "0" {
+			parts = []string{"", ""}
+		} else {
+			return nil, fmt.Errorf("malformed spec: doesn't define a range: %q", spec)
+		}
+	}
+	old := parts[0]
+	ranges := make([]*topodatapb.KeyRange, len(parts)-1)
+
+	for i, p := range parts[1:] {
+		if p == "" && i != (len(parts)-2) {
+			return nil, fmt.Errorf("malformed spec: MinKey/MaxKey cannot be in the middle of the spec: %q", spec)
+		}
+		if p != "" && p <= old {
+			return nil, fmt.Errorf("malformed spec: shard limits should be in order: %q", spec)
+		}
+		s, err := hex.DecodeString(old)
+		if err != nil {
+			return nil, err
+		}
+		if len(s) == 0 {
+			s = nil
+		}
+		e, err := hex.DecodeString(p)
+		if err != nil {
+			return nil, err
+		}
+		if len(e) == 0 {
+			e = nil
+		}
+		ranges[i] = &topodatapb.KeyRange{Start: s, End: e}
+		old = p
+	}
+	return ranges, nil
+}
+
+// IsValidKeyRange returns true if the string represents a valid key range.
+func IsValidKeyRange(keyRangeString string) bool {
+	return KeyRangePattern.MatchString(keyRangeString)
+}
 
 // EvenShardsKeyRange returns a key range definition for a shard at index "i",
 // assuming range based sharding with "n" equal-width shards in total.
@@ -105,257 +363,6 @@ func EvenShardsKeyRange(i, n int) (*topodatapb.KeyRange, error) {
 		endBytes = []byte{}
 	}
 	return &topodatapb.KeyRange{Start: startBytes, End: endBytes}, nil
-}
-
-// KeyRangeAdd adds two adjacent keyranges into a single value.
-// If the values are not adjacent, it returns false.
-func KeyRangeAdd(first, second *topodatapb.KeyRange) (*topodatapb.KeyRange, bool) {
-	if first == nil || second == nil {
-		return nil, false
-	}
-	if len(first.End) != 0 && bytes.Equal(first.End, second.Start) {
-		return &topodatapb.KeyRange{Start: first.Start, End: second.End}, true
-	}
-	if len(second.End) != 0 && bytes.Equal(second.End, first.Start) {
-		return &topodatapb.KeyRange{Start: second.Start, End: first.End}, true
-	}
-	return nil, false
-}
-
-// KeyRangeContains returns true if the provided id is in the keyrange.
-func KeyRangeContains(kr *topodatapb.KeyRange, id []byte) bool {
-	if kr == nil {
-		return true
-	}
-	return bytes.Compare(kr.Start, id) <= 0 &&
-		(len(kr.End) == 0 || bytes.Compare(id, kr.End) < 0)
-}
-
-// ParseKeyRangeParts parses a start and end hex values and build a proto KeyRange
-func ParseKeyRangeParts(start, end string) (*topodatapb.KeyRange, error) {
-	s, err := hex.DecodeString(start)
-	if err != nil {
-		return nil, err
-	}
-	e, err := hex.DecodeString(end)
-	if err != nil {
-		return nil, err
-	}
-	return &topodatapb.KeyRange{Start: s, End: e}, nil
-}
-
-// KeyRangeString prints a topodatapb.KeyRange
-func KeyRangeString(k *topodatapb.KeyRange) string {
-	if k == nil {
-		return "-"
-	}
-	return hex.EncodeToString(k.Start) + "-" + hex.EncodeToString(k.End)
-}
-
-// KeyRangeIsPartial returns true if the KeyRange does not cover the entire space.
-func KeyRangeIsPartial(kr *topodatapb.KeyRange) bool {
-	if kr == nil {
-		return false
-	}
-	return !(len(kr.Start) == 0 && len(kr.End) == 0)
-}
-
-// KeyRangeEqual returns true if both key ranges cover the same area
-func KeyRangeEqual(left, right *topodatapb.KeyRange) bool {
-	if left == nil {
-		return right == nil || (len(right.Start) == 0 && len(right.End) == 0)
-	}
-	if right == nil {
-		return len(left.Start) == 0 && len(left.End) == 0
-	}
-	return bytes.Equal(addPadding(left.Start), addPadding(right.Start)) &&
-		bytes.Equal(addPadding(left.End), addPadding(right.End))
-}
-
-// addPadding adds padding to make sure keyrange represents an 8 byte integer.
-// From Vitess docs:
-// A hash vindex produces an 8-byte number.
-// This means that all numbers less than 0x8000000000000000 will fall in shard -80.
-// Any number with the highest bit set will be >= 0x8000000000000000, and will therefore
-// belong to shard 80-.
-// This means that from a keyrange perspective -80 == 00-80 == 0000-8000 == 000000-800000
-// If we don't add this padding, we could run into issues when transitioning from keyranges
-// that use 2 bytes to 4 bytes.
-func addPadding(kr []byte) []byte {
-	paddedKr := make([]byte, 8)
-
-	for i := 0; i < len(kr); i++ {
-		paddedKr = append(paddedKr, kr[i])
-	}
-
-	for i := len(kr); i < 8; i++ {
-		paddedKr = append(paddedKr, 0)
-	}
-	return paddedKr
-}
-
-// KeyRangeStartSmaller returns true if right's keyrange start is _after_ left's start
-func KeyRangeStartSmaller(left, right *topodatapb.KeyRange) bool {
-	if left == nil {
-		return right != nil
-	}
-	if right == nil {
-		return false
-	}
-	return bytes.Compare(left.Start, right.Start) < 0
-}
-
-// KeyRangeStartEqual returns true if both key ranges have the same start
-func KeyRangeStartEqual(left, right *topodatapb.KeyRange) bool {
-	if left == nil {
-		return right == nil || len(right.Start) == 0
-	}
-	if right == nil {
-		return len(left.Start) == 0
-	}
-	return bytes.Equal(addPadding(left.Start), addPadding(right.Start))
-}
-
-// KeyRangeContiguous returns true if the end of the left key range exactly
-// matches the start of the right key range (i.e they are contigious)
-func KeyRangeContiguous(left, right *topodatapb.KeyRange) bool {
-	if left == nil {
-		return right == nil || (len(right.Start) == 0 && len(right.End) == 0)
-	}
-	if right == nil {
-		return len(left.Start) == 0 && len(left.End) == 0
-	}
-	return bytes.Equal(addPadding(left.End), addPadding(right.Start))
-}
-
-// KeyRangeEndEqual returns true if both key ranges have the same end
-func KeyRangeEndEqual(left, right *topodatapb.KeyRange) bool {
-	if left == nil {
-		return right == nil || len(right.End) == 0
-	}
-	if right == nil {
-		return len(left.End) == 0
-	}
-	return bytes.Equal(addPadding(left.End), addPadding(right.End))
-}
-
-// For more info on the following functions, see:
-// See: http://stackoverflow.com/questions/4879315/what-is-a-tidy-algorithm-to-find-overlapping-intervals
-// two segments defined as (a,b) and (c,d) (with a<b and c<d):
-// intersects = (b > c) && (a < d)
-// overlap = min(b, d) - max(c, a)
-
-// KeyRangesIntersect returns true if some Keyspace values exist in both ranges.
-func KeyRangesIntersect(first, second *topodatapb.KeyRange) bool {
-	if first == nil || second == nil {
-		return true
-	}
-	return (len(first.End) == 0 || bytes.Compare(second.Start, first.End) < 0) &&
-		(len(second.End) == 0 || bytes.Compare(first.Start, second.End) < 0)
-}
-
-// KeyRangesOverlap returns the overlap between two KeyRanges.
-// They need to overlap, otherwise an error is returned.
-func KeyRangesOverlap(first, second *topodatapb.KeyRange) (*topodatapb.KeyRange, error) {
-	if !KeyRangesIntersect(first, second) {
-		return nil, fmt.Errorf("KeyRanges %v and %v don't overlap", first, second)
-	}
-	if first == nil {
-		return second, nil
-	}
-	if second == nil {
-		return first, nil
-	}
-	// compute max(c,a) and min(b,d)
-	// start with (a,b)
-	result := proto.Clone(first).(*topodatapb.KeyRange)
-	// if c > a, then use c
-	if bytes.Compare(second.Start, first.Start) > 0 {
-		result.Start = second.Start
-	}
-	// if b is maxed out, or
-	// (d is not maxed out and d < b)
-	//                           ^ valid test as neither b nor d are max
-	// then use d
-	if len(first.End) == 0 || (len(second.End) != 0 && bytes.Compare(second.End, first.End) < 0) {
-		result.End = second.End
-	}
-	return result, nil
-}
-
-// KeyRangeIncludes returns true if the first provided KeyRange, big,
-// contains the second KeyRange, small. If they intersect, but small
-// spills out, this returns false.
-func KeyRangeIncludes(big, small *topodatapb.KeyRange) bool {
-	if big == nil {
-		// The outside one covers everything, we're good.
-		return true
-	}
-	if small == nil {
-		// The smaller one covers everything, better have the
-		// bigger one also cover everything.
-		return len(big.Start) == 0 && len(big.End) == 0
-	}
-	// Now we check small.Start >= big.Start, and small.End <= big.End
-	if len(big.Start) != 0 && bytes.Compare(small.Start, big.Start) < 0 {
-		return false
-	}
-	if len(big.End) != 0 && (len(small.End) == 0 || bytes.Compare(small.End, big.End) > 0) {
-		return false
-	}
-	return true
-}
-
-// ParseShardingSpec parses a string that describes a sharding
-// specification. a-b-c-d will be parsed as a-b, b-c, c-d. The empty
-// string may serve both as the start and end of the keyspace: -a-b-
-// will be parsed as start-a, a-b, b-end.
-// "0" is treated as "-", to allow us to not have to special-case
-// client code.
-func ParseShardingSpec(spec string) ([]*topodatapb.KeyRange, error) {
-	parts := strings.Split(spec, "-")
-	if len(parts) == 1 {
-		if spec == "0" {
-			parts = []string{"", ""}
-		} else {
-			return nil, fmt.Errorf("malformed spec: doesn't define a range: %q", spec)
-		}
-	}
-	old := parts[0]
-	ranges := make([]*topodatapb.KeyRange, len(parts)-1)
-
-	for i, p := range parts[1:] {
-		if p == "" && i != (len(parts)-2) {
-			return nil, fmt.Errorf("malformed spec: MinKey/MaxKey cannot be in the middle of the spec: %q", spec)
-		}
-		if p != "" && p <= old {
-			return nil, fmt.Errorf("malformed spec: shard limits should be in order: %q", spec)
-		}
-		s, err := hex.DecodeString(old)
-		if err != nil {
-			return nil, err
-		}
-		if len(s) == 0 {
-			s = nil
-		}
-		e, err := hex.DecodeString(p)
-		if err != nil {
-			return nil, err
-		}
-		if len(e) == 0 {
-			e = nil
-		}
-		ranges[i] = &topodatapb.KeyRange{Start: s, End: e}
-		old = p
-	}
-	return ranges, nil
-}
-
-var krRegexp = regexp.MustCompile(`^[0-9a-fA-F]*-[0-9a-fA-F]*$`)
-
-// IsKeyRange returns true if the string represents a keyrange.
-func IsKeyRange(kr string) bool {
-	return krRegexp.MatchString(kr)
 }
 
 // GenerateShardRanges returns shard ranges assuming a keyspace with N shards.

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -304,7 +304,7 @@ func (ts *Server) CreateShard(ctx context.Context, keyspace, shard string) (err 
 		return err
 	}
 	for _, si := range sis {
-		if si.KeyRange == nil || key.KeyRangesIntersect(si.KeyRange, keyRange) {
+		if si.KeyRange == nil || key.KeyRangeIntersect(si.KeyRange, keyRange) {
 			value.IsPrimaryServing = false
 			break
 		}

--- a/go/vt/topo/topoproto/srvkeyspace.go
+++ b/go/vt/topo/topoproto/srvkeyspace.go
@@ -17,8 +17,9 @@ limitations under the License.
 package topoproto
 
 import (
-	"bytes"
 	"sort"
+
+	"vitess.io/vitess/go/vt/key"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
@@ -29,18 +30,12 @@ type ShardReferenceArray []*topodatapb.ShardReference
 // Len implements sort.Interface
 func (sra ShardReferenceArray) Len() int { return len(sra) }
 
-// Len implements sort.Interface
+// Less implements sort.Interface
 func (sra ShardReferenceArray) Less(i, j int) bool {
-	if sra[i].KeyRange == nil || len(sra[i].KeyRange.Start) == 0 {
-		return true
-	}
-	if sra[j].KeyRange == nil || len(sra[j].KeyRange.Start) == 0 {
-		return false
-	}
-	return bytes.Compare(sra[i].KeyRange.Start, sra[j].KeyRange.Start) < 0
+	return key.KeyRangeLess(sra[i].KeyRange, sra[j].KeyRange)
 }
 
-// Len implements sort.Interface
+// Swap implements sort.Interface
 func (sra ShardReferenceArray) Swap(i, j int) {
 	sra[i], sra[j] = sra[j], sra[i]
 }

--- a/go/vt/topotools/split.go
+++ b/go/vt/topotools/split.go
@@ -222,7 +222,7 @@ func findOverlappingShards(shardMap map[string]*topo.ShardInfo) ([]*OverlappingS
 func findIntersectingShard(shardMap map[string]*topo.ShardInfo, sourceArray []*topo.ShardInfo) *topo.ShardInfo {
 	for name, si := range shardMap {
 		for _, sourceShardInfo := range sourceArray {
-			if si.KeyRange == nil || sourceShardInfo.KeyRange == nil || key.KeyRangesIntersect(si.KeyRange, sourceShardInfo.KeyRange) {
+			if si.KeyRange == nil || sourceShardInfo.KeyRange == nil || key.KeyRangeIntersect(si.KeyRange, sourceShardInfo.KeyRange) {
 				delete(shardMap, name)
 				return si
 			}
@@ -235,7 +235,7 @@ func findIntersectingShard(shardMap map[string]*topo.ShardInfo, sourceArray []*t
 // in the destination array
 func intersect(si *topo.ShardInfo, allShards []*topo.ShardInfo) bool {
 	for _, shard := range allShards {
-		if key.KeyRangesIntersect(si.KeyRange, shard.KeyRange) {
+		if key.KeyRangeIntersect(si.KeyRange, shard.KeyRange) {
 			return true
 		}
 	}

--- a/go/vt/topotools/split_test.go
+++ b/go/vt/topotools/split_test.go
@@ -130,6 +130,10 @@ func TestValidateForReshard(t *testing.T) {
 		targets: []string{"-40", "40-"},
 		out:     "",
 	}, {
+		sources: []string{"0003-"},
+		targets: []string{"000300-000380", "000380-000400", "0004-"},
+		out:     "",
+	}, {
 		sources: []string{"-40", "40-80", "80-"},
 		targets: []string{"-40", "40-"},
 		out:     "same keyrange is present in source and target: -40",

--- a/go/vt/vtctl/workflow/stream_migrator.go
+++ b/go/vt/vtctl/workflow/stream_migrator.go
@@ -653,7 +653,7 @@ func (sm *StreamMigrator) templatizeRule(ctx context.Context, rule *binlogdatapb
 	switch {
 	case rule.Filter == "":
 		return StreamTypeUnknown, fmt.Errorf("rule %v does not have a select expression in vreplication", rule)
-	case key.IsKeyRange(rule.Filter):
+	case key.IsValidKeyRange(rule.Filter):
 		rule.Filter = "{{.}}"
 		return StreamTypeSharded, nil
 	case rule.Filter == vreplication.ExcludeStr:

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ.go
@@ -236,7 +236,7 @@ func (wd *workflowDiffer) buildPlan(dbClient binlogplayer.DBClient, filter *binl
 			buf := sqlparser.NewTrackedBuffer(nil)
 			buf.Myprintf("select * from %v", sqlparser.NewIdentifierCS(table.Name))
 			sourceQuery = buf.String()
-		case key.IsKeyRange(rule.Filter):
+		case key.IsValidKeyRange(rule.Filter):
 			buf := sqlparser.NewTrackedBuffer(nil)
 			buf.Myprintf("select * from %v where in_keyrange(%v)", sqlparser.NewIdentifierCS(table.Name), sqlparser.NewStrLiteral(rule.Filter))
 			sourceQuery = buf.String()

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -201,7 +201,7 @@ func buildTablePlan(tableName string, rule *binlogdatapb.Rule, colInfos []*Colum
 		buf := sqlparser.NewTrackedBuffer(nil)
 		buf.Myprintf("select * from %v", sqlparser.NewIdentifierCS(tableName))
 		query = buf.String()
-	case key.IsKeyRange(filter):
+	case key.IsValidKeyRange(filter):
 		buf := sqlparser.NewTrackedBuffer(nil)
 		buf.Myprintf("select * from %v where in_keyrange(%v)", sqlparser.NewIdentifierCS(tableName), sqlparser.NewStrLiteral(filter))
 		query = buf.String()

--- a/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go
@@ -216,7 +216,7 @@ func getQuery(tableName string, filter string) string {
 		buf := sqlparser.NewTrackedBuffer(nil)
 		buf.Myprintf("select * from %v", sqlparser.NewIdentifierCS(tableName))
 		query = buf.String()
-	case key.IsKeyRange(filter):
+	case key.IsValidKeyRange(filter):
 		buf := sqlparser.NewTrackedBuffer(nil)
 		buf.Myprintf("select * from %v where in_keyrange(%v)", sqlparser.NewIdentifierCS(tableName), sqlparser.NewStrLiteral(filter))
 		query = buf.String()

--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -1224,7 +1224,7 @@ func (mz *materializer) generateInserts(ctx context.Context, targetShard *topo.S
 		// We only do it for MoveTables for now since this doesn't hold for materialize flows
 		// where the target's sharding key might differ from that of the source
 		if mz.ms.MaterializationIntent == vtctldatapb.MaterializationIntent_MOVETABLES &&
-			!key.KeyRangesIntersect(sourceShard.KeyRange, targetShard.KeyRange) {
+			!key.KeyRangeIntersect(sourceShard.KeyRange, targetShard.KeyRange) {
 			continue
 		}
 		bls := &binlogdatapb.BinlogSource{

--- a/go/vt/wrangler/resharder.go
+++ b/go/vt/wrangler/resharder.go
@@ -313,7 +313,7 @@ func (rs *resharder) createStreams(ctx context.Context) error {
 		// copy excludeRules to prevent data race.
 		copyExcludeRules := append([]*binlogdatapb.Rule(nil), excludeRules...)
 		for _, source := range rs.sourceShards {
-			if !key.KeyRangesIntersect(target.KeyRange, source.KeyRange) {
+			if !key.KeyRangeIntersect(target.KeyRange, source.KeyRange) {
 				continue
 			}
 			filter := &binlogdatapb.Filter{

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -949,9 +949,7 @@ func (ts *trafficSwitcher) isPartialMoveTables(sourceShards, targetShards []stri
 		return false, err
 	}
 
-	if !key.KeyRangeIsPartial(skr) || !key.KeyRangeIsPartial(tkr) || // both cover full range
-		len(sourceShards) != len(targetShards) {
-
+	if key.KeyRangeIsComplete(skr) || key.KeyRangeIsComplete(tkr) || len(sourceShards) != len(targetShards) {
 		return false, nil
 	}
 

--- a/go/vt/wrangler/traffic_switcher_env_test.go
+++ b/go/vt/wrangler/traffic_switcher_env_test.go
@@ -343,7 +343,7 @@ func newTestShardMigrater(ctx context.Context, t *testing.T, sourceShards, targe
 		var rows, rowsRdOnly []string
 		var streamExtInfoRows []string
 		for j, sourceShard := range sourceShards {
-			if !key.KeyRangesIntersect(tme.targetKeyRanges[i], tme.sourceKeyRanges[j]) {
+			if !key.KeyRangeIntersect(tme.targetKeyRanges[i], tme.sourceKeyRanges[j]) {
 				continue
 			}
 			bls := &binlogdatapb.BinlogSource{
@@ -490,7 +490,7 @@ func (tme *testMigraterEnv) expectNoPreviousReverseJournals() {
 func (tme *testShardMigraterEnv) forAllStreams(f func(i, j int)) {
 	for i := range tme.targetShards {
 		for j := range tme.sourceShards {
-			if !key.KeyRangesIntersect(tme.targetKeyRanges[i], tme.sourceKeyRanges[j]) {
+			if !key.KeyRangeIntersect(tme.targetKeyRanges[i], tme.sourceKeyRanges[j]) {
 				continue
 			}
 			f(i, j)

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -398,7 +398,7 @@ func (df *vdiff) buildVDiffPlan(ctx context.Context, filter *binlogdatapb.Filter
 			continue
 		}
 		query := rule.Filter
-		if rule.Filter == "" || key.IsKeyRange(rule.Filter) {
+		if rule.Filter == "" || key.IsValidKeyRange(rule.Filter) {
 			buf := sqlparser.NewTrackedBuffer(nil)
 			buf.Myprintf("select * from %v", sqlparser.NewIdentifierCS(table.Name))
 			query = buf.String()


### PR DESCRIPTION
Address internal review comments



Fix apparent bug in KeyRangeContiguous when a or b are full-range



Add test for bug in comparing "0003" vs "000300"



Remove trailing zeroes in key.Normalize instead of adding padding



Address review feedback; test formatting, comments, function naming



Refactor tests for TestKeyRangesIntersect



Rename KeyRangesIntersect to KeyRangeIntersect for consistency



Remove unused KeyRangesOverlap function



Rename KeyRangeIncludes to KeyRangeContainsKeyRange, clean up and add tests

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
