### PR TITLE
Use debian 11 version of percona-xtrabackup

### DIFF
--- a/docker/lite/install_dependencies.sh
+++ b/docker/lite/install_dependencies.sh
@@ -83,25 +83,30 @@ mysql57)
     )
     ;;
 mysql80)
-    mysql8_version=8.0.30
-    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/libmysqlclient21_${mysql8_version}-1debian10_amd64.deb /tmp/libmysqlclient21_${mysql8_version}-1debian10_amd64.deb
-    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-client-core_${mysql8_version}-1debian10_amd64.deb /tmp/mysql-community-client-core_${mysql8_version}-1debian10_amd64.deb
-    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-client-plugins_${mysql8_version}-1debian10_amd64.deb /tmp/mysql-community-client-plugins_${mysql8_version}-1debian10_amd64.deb
-    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-client_${mysql8_version}-1debian10_amd64.deb /tmp/mysql-community-client_${mysql8_version}-1debian10_amd64.deb
-    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-client_${mysql8_version}-1debian10_amd64.deb /tmp/mysql-client_${mysql8_version}-1debian10_amd64.deb
-    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-server-core_${mysql8_version}-1debian10_amd64.deb /tmp/mysql-community-server-core_${mysql8_version}-1debian10_amd64.deb
-    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-server_${mysql8_version}-1debian10_amd64.deb /tmp/mysql-community-server_${mysql8_version}-1debian10_amd64.deb
-    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-server_${mysql8_version}-1debian10_amd64.deb /tmp/mysql-server_${mysql8_version}-1debian10_amd64.deb
+    if [ -z "$VERSION" ]; then
+        VERSION=8.0.30
+    fi
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-common_${VERSION}-1debian11_amd64.deb /tmp/mysql-common_${VERSION}-1debian11_amd64.deb
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/libmysqlclient21_${VERSION}-1debian11_amd64.deb /tmp/libmysqlclient21_${VERSION}-1debian11_amd64.deb
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-client-core_${VERSION}-1debian11_amd64.deb /tmp/mysql-community-client-core_${VERSION}-1debian11_amd64.deb
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-client-plugins_${VERSION}-1debian11_amd64.deb /tmp/mysql-community-client-plugins_${VERSION}-1debian11_amd64.deb
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-client_${VERSION}-1debian11_amd64.deb /tmp/mysql-community-client_${VERSION}-1debian11_amd64.deb
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-client_${VERSION}-1debian11_amd64.deb /tmp/mysql-client_${VERSION}-1debian11_amd64.deb
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-server-core_${VERSION}-1debian11_amd64.deb /tmp/mysql-community-server-core_${VERSION}-1debian11_amd64.deb
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-server_${VERSION}-1debian11_amd64.deb /tmp/mysql-community-server_${VERSION}-1debian11_amd64.deb
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-server_${VERSION}-1debian11_amd64.deb /tmp/mysql-server_${VERSION}-1debian11_amd64.deb
+    do_fetch https://downloads.percona.com/downloads/Percona-XtraBackup-8.0/Percona-XtraBackup-8.0.34-29/binary/debian/bullseye/x86_64/percona-xtrabackup-80_8.0.34-29-1.bullseye_amd64.deb /tmp/percona-xtrabackup-80_8.0.34-29-1.bullseye_amd64.deb
     PACKAGES=(
-        /tmp/libmysqlclient21_${mysql8_version}-1debian10_amd64.deb
-        /tmp/mysql-community-client-core_${mysql8_version}-1debian10_amd64.deb
-        /tmp/mysql-community-client-plugins_${mysql8_version}-1debian10_amd64.deb
-        /tmp/mysql-community-client_${mysql8_version}-1debian10_amd64.deb
-        /tmp/mysql-client_${mysql8_version}-1debian10_amd64.deb
-        /tmp/mysql-community-server-core_${mysql8_version}-1debian10_amd64.deb
-        /tmp/mysql-community-server_${mysql8_version}-1debian10_amd64.deb
-        /tmp/mysql-server_${mysql8_version}-1debian10_amd64.deb
-        percona-xtrabackup-80
+        /tmp/mysql-common_${VERSION}-1debian11_amd64.deb
+        /tmp/libmysqlclient21_${VERSION}-1debian11_amd64.deb
+        /tmp/mysql-community-client-core_${VERSION}-1debian11_amd64.deb
+        /tmp/mysql-community-client-plugins_${VERSION}-1debian11_amd64.deb
+        /tmp/mysql-community-client_${VERSION}-1debian11_amd64.deb
+        /tmp/mysql-client_${VERSION}-1debian11_amd64.deb
+        /tmp/mysql-community-server-core_${VERSION}-1debian11_amd64.deb
+        /tmp/mysql-community-server_${VERSION}-1debian11_amd64.deb
+        /tmp/mysql-server_${VERSION}-1debian11_amd64.deb
+        /tmp/percona-xtrabackup-80_8.0.34-29-1.bullseye_amd64.deb
     )
     ;;
 percona)


### PR DESCRIPTION
The percona-xtrabackup-80 package depends on
a package that is not avaialable in the debian 11 repositories, hence the image build trying to install this package on debian 11 (bullseye) always fails.

Percona provides this package via regular downloads for debian 11, so we use that to install the compatible package for a successful build.

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
