### PR TITLE
Backport: set vreplication net read and net write timeout session vars to high values

### DIFF
--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -356,6 +356,8 @@ Usage of vttablet:
       --vreplication_healthcheck_topology_refresh duration               refresh interval for re-reading the topology (default 30s)
       --vreplication_heartbeat_update_interval int                       Frequency (in seconds, default 1, max 60) at which the time_updated column of a vreplication stream when idling (default 1)
       --vreplication_max_time_to_retry_on_error duration                 stop automatically retrying when we've had consecutive failures with the same error for this long after the first occurrence
+      --vreplication_net_read_timeout int                                Session value of net_read_timeout for vreplication, in seconds (default 300)
+      --vreplication_net_write_timeout int                               Session value of net_write_timeout for vreplication, in seconds (default 600)
       --vreplication_replica_lag_tolerance duration                      Replica lag threshold duration: once lag is below this we switch from copy phase to the replication (streaming) phase (default 1m0s)
       --vreplication_retry_delay duration                                delay before retrying a failed workflow event in the replication phase (default 5s)
       --vreplication_store_compressed_gtid                               Store compressed gtids in the pos column of _vt.vreplication

--- a/go/vt/vttablet/flags.go
+++ b/go/vt/vttablet/flags.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vttablet
+
+import (
+	"github.com/spf13/pflag"
+
+	"vitess.io/vitess/go/vt/servenv"
+)
+
+var (
+	VReplicationNetReadTimeout    = 300
+	VReplicationNetWriteTimeout   = 600
+)
+
+func init() {
+	servenv.OnParseFor("vttablet", registerFlags)
+}
+
+func registerFlags(fs *pflag.FlagSet) {
+	fs.IntVar(&VReplicationNetReadTimeout, "vreplication_net_read_timeout", VReplicationNetReadTimeout, "Session value of net_read_timeout for vreplication, in seconds")
+	fs.IntVar(&VReplicationNetWriteTimeout, "vreplication_net_write_timeout", VReplicationNetWriteTimeout, "Session value of net_write_timeout for vreplication, in seconds")
+}

--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"time"
 
+	"vitess.io/vitess/go/vt/vttablet"
+
 	"google.golang.org/protobuf/encoding/prototext"
 
 	"vitess.io/vitess/go/vt/discovery"
@@ -243,6 +245,12 @@ func (ct *controller) runBlp(ctx context.Context) (err error) {
 		// Tables may have varying character sets. To ship the bits without interpreting them
 		// we set the character set to be binary.
 		if _, err := dbClient.ExecuteFetch("set names binary", 10000); err != nil {
+			return err
+		}
+		if _, err := dbClient.ExecuteFetch(fmt.Sprintf("set @@session.net_read_timeout = %v", vttablet.VReplicationNetReadTimeout), 10000); err != nil {
+			return err
+		}
+		if _, err := dbClient.ExecuteFetch(fmt.Sprintf("set @@session.net_write_timeout = %v", vttablet.VReplicationNetWriteTimeout), 10000); err != nil {
 			return err
 		}
 		// We must apply AUTO_INCREMENT values precisely as we got them. This include the 0 value, which is not recommended in AUTO_INCREMENT, and yet is valid.

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/vt/vttablet"
+
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/textutil"
@@ -120,6 +122,12 @@ func (rs *rowStreamer) Stream() error {
 	}
 	defer conn.Close()
 	if _, err := conn.ExecuteFetch("set names binary", 1, false); err != nil {
+		return err
+	}
+	if _, err := conn.ExecuteFetch(fmt.Sprintf("set @@session.net_read_timeout = %v", vttablet.VReplicationNetReadTimeout), 1, false); err != nil {
+		return err
+	}
+	if _, err := conn.ExecuteFetch(fmt.Sprintf("set @@session.net_write_timeout = %v", vttablet.VReplicationNetWriteTimeout), 1, false); err != nil {
 		return err
 	}
 	return rs.streamQuery(conn, rs.send)


### PR DESCRIPTION
Backport of https://github.com/vitessio/vitess/commit/69533906ae7cac31dd2b0d603115f3021cded4f7
Redo of #129 onto the newest release.
Part of https://github.com/Shopify/vitess-project/issues/623

Helps with failure of schema changes using `vitess` strategy due to lower than desired timeout values.

⚠️ Does not contain bits from the original PR that reference features that were introduced in releases later than 15. (e.g. change in tablestreamer.go introduced in https://github.com/vitessio/vitess/commit/04ad6ec0ed7d4bb3371eeb1a328eb6c2f56ea53c, and in rpc_vreplication_test.go which was introduced in https://github.com/vitessio/vitess/commit/20e4768de7fb0a78f4f5599bbc46132a913380a4).