### PR TITLE
Backport: VTCombo: Ensure VSchema exists when creating keyspace (#16094)

### DIFF
--- a/go/test/endtoend/vtcombo/vttest_sample_test.go
+++ b/go/test/endtoend/vtcombo/vttest_sample_test.go
@@ -135,6 +135,8 @@ func TestStandalone(t *testing.T) {
 	tmp, _ := cmd.([]any)
 	require.Contains(t, tmp[0], "vtcombo")
 
+	assertVSchemaExists(t, grpcAddress)
+
 	ctx := context.Background()
 	conn, err := vtgateconn.Dial(ctx, grpcAddress)
 	require.NoError(t, err)
@@ -163,6 +165,17 @@ func TestStandalone(t *testing.T) {
 	assertInsertedRowsExist(ctx, t, conn, idStart, rowCount)
 	assertTabletsPresent(t)
 	assertTransactionalityAndRollbackObeyed(ctx, t, conn, idStart)
+}
+
+func assertVSchemaExists(t *testing.T, grpcAddress string) {
+	tmpCmd := exec.Command("vtctldclient", "--server", grpcAddress, "--compact", "GetVSchema", "routed")
+
+	log.Infof("Running vtctldclient with command: %v", tmpCmd.Args)
+
+	output, err := tmpCmd.CombinedOutput()
+	require.NoError(t, err, fmt.Sprintf("Output:\n%v", string(output)))
+
+	assert.Equal(t, "{}\n", string(output))
 }
 
 func assertInsertedRowsExist(ctx context.Context, t *testing.T, conn *vtgateconn.VTGateConn, idStart, rowCount int) {

--- a/go/vt/vtcombo/tablet_map.go
+++ b/go/vt/vtcombo/tablet_map.go
@@ -318,6 +318,11 @@ func CreateKs(
 			return 0, fmt.Errorf("CreateKeyspace(%v) failed: %v", keyspace, err)
 		}
 
+		// make sure a valid vschema has been loaded
+		if err := ts.EnsureVSchema(ctx, keyspace); err != nil {
+			return 0, fmt.Errorf("EnsureVSchema(%v) failed: %v", keyspace, err)
+		}
+
 		// iterate through the shards
 		for _, spb := range kpb.Shards {
 			shard := spb.Name


### PR DESCRIPTION
Backport https://github.com/vitessio/vitess/commit/0f242e9868552baf121c288e0a92781001b150d6