### PR TITLE
Backport: Use default schema reload config values when config file is empty

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -414,8 +414,6 @@ func (cfg *TabletConfig) UnmarshalJSON(data []byte) (err error) {
 		if err != nil {
 			return err
 		}
-	} else {
-		cfg.SchemaReloadInterval = 0
 	}
 
 	if tmp.SignalSchemaChangeReloadInterval != "" {
@@ -432,8 +430,6 @@ func (cfg *TabletConfig) UnmarshalJSON(data []byte) (err error) {
 		if err != nil {
 			return err
 		}
-	} else {
-		cfg.SchemaChangeReloadTimeout = 0
 	}
 
 	return nil

--- a/go/vt/vttablet/tabletserver/tabletenv/config_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config_test.go
@@ -56,6 +56,8 @@ func TestConfigParse(t *testing.T) {
 			MaxInnoDBTrxHistLen: 1000,
 			MaxMySQLReplLagSecs: 400,
 		},
+		SchemaChangeReloadTimeout: 30 * time.Second,
+		SchemaReloadInterval:      30 * time.Minute,
 	}
 
 	gotBytes, err := yaml2.Marshal(&cfg)
@@ -91,6 +93,8 @@ replicationTracker: {}
 rowStreamer:
   maxInnoDBTrxHistLen: 1000
   maxMySQLReplLagSecs: 400
+schemaChangeReloadTimeout: 30s
+schemaReloadIntervalSeconds: 30m0s
 txPool: {}
 `
 	assert.Equal(t, wantBytes, string(gotBytes))


### PR DESCRIPTION
Backports https://github.com/vitessio/vitess/commit/66fbbcf9b562d926824e377010bd1b5cbcdd3fe5