### PR TITLE
Backport: [release-19.0] Fix the install dependencies script in Docker (#16340) (#16346)

### DIFF
--- a/docker/lite/install_dependencies.sh
+++ b/docker/lite/install_dependencies.sh
@@ -66,7 +66,6 @@ BASE_PACKAGES=(
     zstd
 )
 
-percona-release enable-only tools
 apt-get update
 apt-get install -y --no-install-recommends "${BASE_PACKAGES[@]}"
 


### PR DESCRIPTION
Backport https://github.com/vitessio/vitess/commit/3f3a104c4eb7165761969a711e39b0603efc9ae6