### PR TITLE
Release commit for 18.0.5-shopify-3

### DIFF
--- a/examples/compose/docker-compose.beginners.yml
+++ b/examples/compose/docker-compose.beginners.yml
@@ -58,7 +58,7 @@ services:
       - "3306"
 
   vtctld:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
       - "15000:$WEB_PORT"
       - "$GRPC_PORT"
@@ -81,7 +81,7 @@ services:
         condition: service_healthy
 
   vtgate:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
       - "15099:$WEB_PORT"
       - "$GRPC_PORT"
@@ -111,7 +111,7 @@ services:
         condition: service_healthy
 
   schemaload:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     command:
     - sh
     - -c
@@ -144,12 +144,12 @@ services:
     environment:
       - KEYSPACES=$KEYSPACE
       - GRPC_PORT=15999
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     volumes:
       - .:/script
 
   vttablet100:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
       - "15100:$WEB_PORT"
       - "$GRPC_PORT"
@@ -181,7 +181,7 @@ services:
       retries: 15
 
   vttablet101:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
       - "15101:$WEB_PORT"
       - "$GRPC_PORT"
@@ -213,7 +213,7 @@ services:
       retries: 15
 
   vttablet102:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
       - "15102:$WEB_PORT"
       - "$GRPC_PORT"
@@ -245,7 +245,7 @@ services:
       retries: 15
 
   vttablet103:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
       - "15103:$WEB_PORT"
       - "$GRPC_PORT"
@@ -277,7 +277,7 @@ services:
       retries: 15
 
   vtorc:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     command: ["sh", "-c", "/script/vtorc-up.sh"]
     depends_on:
       - vtctld
@@ -307,7 +307,7 @@ services:
       retries: 15
 
   vreplication:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     volumes:
       - ".:/script"
     environment:

--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     - SCHEMA_FILES=lookup_keyspace_schema_file.sql
     - POST_LOAD_FILE=
     - EXTERNAL_DB=0
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     volumes:
     - .:/script
   schemaload_test_keyspace:
@@ -101,7 +101,7 @@ services:
     - SCHEMA_FILES=test_keyspace_schema_file.sql
     - POST_LOAD_FILE=
     - EXTERNAL_DB=0
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     volumes:
     - .:/script
   set_keyspace_durability_policy:
@@ -115,7 +115,7 @@ services:
     environment:
       - KEYSPACES=test_keyspace lookup_keyspace
       - GRPC_PORT=15999
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     volumes:
       - .:/script
   vreplication:
@@ -129,7 +129,7 @@ services:
     - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
       --topo_global_root vitess/global
     - EXTERNAL_DB=0
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     volumes:
     - .:/script
   vtctld:
@@ -143,7 +143,7 @@ services:
     depends_on:
       external_db_host:
         condition: service_healthy
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
     - 15000:8080
     - "15999"
@@ -160,7 +160,7 @@ services:
       --normalize_queries=true '
     depends_on:
     - vtctld
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
     - 15099:8080
     - "15999"
@@ -182,7 +182,7 @@ services:
     - EXTERNAL_DB=0
     - DB_USER=
     - DB_PASS=
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
     - 13000:8080
     volumes:
@@ -217,7 +217,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
     - 15101:8080
     - "15999"
@@ -254,7 +254,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
     - 15102:8080
     - "15999"
@@ -291,7 +291,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
     - 15201:8080
     - "15999"
@@ -328,7 +328,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
     - 15202:8080
     - "15999"
@@ -365,7 +365,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
     - 15301:8080
     - "15999"
@@ -402,7 +402,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
     - 15302:8080
     - "15999"

--- a/examples/compose/vtcompose/docker-compose.test.yml
+++ b/examples/compose/vtcompose/docker-compose.test.yml
@@ -79,7 +79,7 @@ services:
       - SCHEMA_FILES=test_keyspace_schema_file.sql
       - POST_LOAD_FILE=
       - EXTERNAL_DB=0
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     volumes:
       - .:/script
   schemaload_unsharded_keyspace:
@@ -103,7 +103,7 @@ services:
       - SCHEMA_FILES=unsharded_keyspace_schema_file.sql
       - POST_LOAD_FILE=
       - EXTERNAL_DB=0
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     volumes:
       - .:/script
   set_keyspace_durability_policy_test_keyspace:
@@ -117,7 +117,7 @@ services:
     environment:
       - GRPC_PORT=15999
       - KEYSPACES=test_keyspace
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     volumes:
       - .:/script
   set_keyspace_durability_policy_unsharded_keyspace:
@@ -130,7 +130,7 @@ services:
     environment:
       - GRPC_PORT=15999
       - KEYSPACES=unsharded_keyspace
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     volumes:
       - .:/script
   vreplication:
@@ -144,7 +144,7 @@ services:
       - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
         --topo_global_root vitess/global
       - EXTERNAL_DB=0
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     volumes:
       - .:/script
   vtctld:
@@ -159,7 +159,7 @@ services:
     depends_on:
       external_db_host:
         condition: service_healthy
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
       - 15000:8080
       - "15999"
@@ -176,7 +176,7 @@ services:
       ''grpc-vtgateservice'' --normalize_queries=true '
     depends_on:
       - vtctld
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
       - 15099:8080
       - "15999"
@@ -199,7 +199,7 @@ services:
       - EXTERNAL_DB=0
       - DB_USER=
       - DB_PASS=
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
       - 13000:8080
     volumes:
@@ -234,7 +234,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
       - 15101:8080
       - "15999"
@@ -271,7 +271,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
       - 15102:8080
       - "15999"
@@ -308,7 +308,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
       - 15201:8080
       - "15999"
@@ -345,7 +345,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
       - 15202:8080
       - "15999"
@@ -382,7 +382,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
       - 15301:8080
       - "15999"

--- a/examples/compose/vtcompose/vtcompose.go
+++ b/examples/compose/vtcompose/vtcompose.go
@@ -533,7 +533,7 @@ func generateDefaultShard(tabAlias int, shard string, keyspaceData keyspaceInfo,
 - op: add
   path: /services/init_shard_primary%[2]d
   value:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     command: ["sh", "-c", "/vt/bin/vtctldclient %[5]s InitShardPrimary --force %[4]s/%[3]s %[6]s-%[2]d "]
     %[1]s
 `, dependsOn, aliases[0], shard, keyspaceData.keyspace, opts.topologyFlags, opts.cell)
@@ -565,7 +565,7 @@ func generateExternalPrimary(
 - op: add
   path: /services/vttablet%[1]d
   value:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
       - "15%[1]d:%[3]d"
       - "%[4]d"
@@ -627,7 +627,7 @@ func generateDefaultTablet(tabAlias int, shard, role, keyspace string, dbInfo ex
 - op: add
   path: /services/vttablet%[1]d
   value:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
     - "15%[1]d:%[4]d"
     - "%[5]d"
@@ -665,7 +665,7 @@ func generateVtctld(opts vtOptions) string {
 - op: add
   path: /services/vtctld
   value:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
       - "15000:%[1]d"
       - "%[2]d"
@@ -696,7 +696,7 @@ func generateVtgate(opts vtOptions) string {
 - op: add
   path: /services/vtgate
   value:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     ports:
       - "15099:%[1]d"
       - "%[2]d"
@@ -738,7 +738,7 @@ func generateVTOrc(dbInfo externalDbInfo, keyspaceInfoMap map[string]keyspaceInf
 - op: add
   path: /services/vtorc
   value:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     volumes:
       - ".:/script"
     environment:
@@ -763,7 +763,7 @@ func generateVreplication(dbInfo externalDbInfo, opts vtOptions) string {
 - op: add
   path: /services/vreplication
   value:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     volumes:
       - ".:/script"
     environment:
@@ -791,7 +791,7 @@ func generateSetKeyspaceDurabilityPolicy(
 - op: add
   path: /services/set_keyspace_durability_policy_%[3]s
   value:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     volumes:
       - ".:/script"
     environment:
@@ -828,7 +828,7 @@ func generateSchemaload(
 - op: add
   path: /services/schemaload_%[7]s
   value:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.5-shopify-3
     volumes:
       - ".:/script"
     environment:

--- a/examples/operator/101_initial_cluster.yaml
+++ b/examples/operator/101_initial_cluster.yaml
@@ -8,14 +8,14 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v18.0.5
-    vtadmin: vitess/vtadmin:v18.0.5
-    vtgate: vitess/lite:v18.0.5
-    vttablet: vitess/lite:v18.0.5
-    vtbackup: vitess/lite:v18.0.5
-    vtorc: vitess/lite:v18.0.5
+    vtctld: vitess/lite:v18.0.5-shopify-3
+    vtadmin: vitess/vtadmin:v18.0.5-shopify-3
+    vtgate: vitess/lite:v18.0.5-shopify-3
+    vttablet: vitess/lite:v18.0.5-shopify-3
+    vtbackup: vitess/lite:v18.0.5-shopify-3
+    vtorc: vitess/lite:v18.0.5-shopify-3
     mysqld:
-      mysql80Compatible: vitess/lite:v18.0.5
+      mysql80Compatible: vitess/lite:v18.0.5-shopify-3
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/201_customer_tablets.yaml
+++ b/examples/operator/201_customer_tablets.yaml
@@ -4,14 +4,14 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v18.0.5
-    vtadmin: vitess/vtadmin:v18.0.5
-    vtgate: vitess/lite:v18.0.5
-    vttablet: vitess/lite:v18.0.5
-    vtbackup: vitess/lite:v18.0.5
-    vtorc: vitess/lite:v18.0.5
+    vtctld: vitess/lite:v18.0.5-shopify-3
+    vtadmin: vitess/vtadmin:v18.0.5-shopify-3
+    vtgate: vitess/lite:v18.0.5-shopify-3
+    vttablet: vitess/lite:v18.0.5-shopify-3
+    vtbackup: vitess/lite:v18.0.5-shopify-3
+    vtorc: vitess/lite:v18.0.5-shopify-3
     mysqld:
-      mysql80Compatible: vitess/lite:v18.0.5
+      mysql80Compatible: vitess/lite:v18.0.5-shopify-3
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/302_new_shards.yaml
+++ b/examples/operator/302_new_shards.yaml
@@ -4,14 +4,14 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v18.0.5
-    vtadmin: vitess/vtadmin:v18.0.5
-    vtgate: vitess/lite:v18.0.5
-    vttablet: vitess/lite:v18.0.5
-    vtbackup: vitess/lite:v18.0.5
-    vtorc: vitess/lite:v18.0.5
+    vtctld: vitess/lite:v18.0.5-shopify-3
+    vtadmin: vitess/vtadmin:v18.0.5-shopify-3
+    vtgate: vitess/lite:v18.0.5-shopify-3
+    vttablet: vitess/lite:v18.0.5-shopify-3
+    vtbackup: vitess/lite:v18.0.5-shopify-3
+    vtorc: vitess/lite:v18.0.5-shopify-3
     mysqld:
-      mysql80Compatible: vitess/lite:v18.0.5
+      mysql80Compatible: vitess/lite:v18.0.5-shopify-3
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/306_down_shard_0.yaml
+++ b/examples/operator/306_down_shard_0.yaml
@@ -4,14 +4,14 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v18.0.5
-    vtadmin: vitess/vtadmin:v18.0.5
-    vtgate: vitess/lite:v18.0.5
-    vttablet: vitess/lite:v18.0.5
-    vtbackup: vitess/lite:v18.0.5
-    vtorc: vitess/lite:v18.0.5
+    vtctld: vitess/lite:v18.0.5-shopify-3
+    vtadmin: vitess/vtadmin:v18.0.5-shopify-3
+    vtgate: vitess/lite:v18.0.5-shopify-3
+    vttablet: vitess/lite:v18.0.5-shopify-3
+    vtbackup: vitess/lite:v18.0.5-shopify-3
+    vtorc: vitess/lite:v18.0.5-shopify-3
     mysqld:
-      mysql80Compatible: vitess/lite:v18.0.5
+      mysql80Compatible: vitess/lite:v18.0.5-shopify-3
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/go/vt/servenv/version.go
+++ b/go/vt/servenv/version.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package servenv
 
+// THIS FILE IS AUTO-GENERATED DURING NEW RELEASES BY ./tools/do_releases.sh
 // DO NOT EDIT
-// THIS FILE IS AUTO-GENERATED DURING NEW RELEASES BY THE VITESS-RELEASER
 
-const versionName = "18.0.5"
+const versionName = "18.0.5-shopify-3"

--- a/java/client/pom.xml
+++ b/java/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>18.0.5</version>
+    <version>18.0.5-shopify-3</version>
   </parent>
   <artifactId>vitess-client</artifactId>
 

--- a/java/example/pom.xml
+++ b/java/example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>18.0.5</version>
+    <version>18.0.5-shopify-3</version>
   </parent>
   <artifactId>vitess-example</artifactId>
 

--- a/java/grpc-client/pom.xml
+++ b/java/grpc-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>18.0.5</version>
+    <version>18.0.5-shopify-3</version>
   </parent>
   <artifactId>vitess-grpc-client</artifactId>
 

--- a/java/jdbc/pom.xml
+++ b/java/jdbc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>18.0.5</version>
+    <version>18.0.5-shopify-3</version>
   </parent>
   <artifactId>vitess-jdbc</artifactId>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>io.vitess</groupId>
   <artifactId>vitess-parent</artifactId>
-  <version>18.0.5</version>
+  <version>18.0.5-shopify-3</version>
   <packaging>pom</packaging>
 
   <name>Vitess Java Client libraries [Parent]</name>


### PR DESCRIPTION
Updates the version identifier to include the Shopify patch number

Commands:
```bash
VTOP_VERSION=$(cat examples/operator/operator.yaml | grep -o 'planetscale/vitess-operator:v.*' | sed 's|planetscale/vitess-operator:v\(.*\)|\1|')
make BASE_BRANCH="v18.0.5-shopify-3" BASE_REMOTE="origin" RELEASE_VERSION="18.0.5-shopify-3" VTOP_VERSION=$VTOP_VERSION create_release
```

Result:
```
bin/vttestserver --version
vttestserver version Version: 18.0.5-shopify-3 (Git revision fe8cb8a5726626d6794ad316963ebc5555859c7d branch 'v18.0.5-shopify-3-create_release-1') built on Thu Jul 25 14:39:50 EDT 2024 by brendan@slab using go1.22.4 darwin/arm64
```

```
bin/vttestserver --port 4440 --keyspaces foo &


mysql --host 127.0.0.1 --port 4443 --user root
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 1
Server version: 8.0.30-Vitess Version: 18.0.5-shopify-3 (Git revision fe8cb8a5726626d6794ad316963ebc5555859c7d branch 'v18.0.5-shopify-3-create_release-1') built on Thu Jul 25 14:39:50 EDT 2024 by brendan@slab using go1.22.4 darwin/arm64
```