### PR TITLE
Backport: vtcombo: close query service on drop database

### DIFF
--- a/go/vt/vtcombo/tablet_map.go
+++ b/go/vt/vtcombo/tablet_map.go
@@ -234,7 +234,11 @@ func DeleteKs(
 			tablet.tm.Stop()
 			tablet.tm.Close()
 			tablet.qsc.SchemaEngine().Close()
-			err := ts.DeleteTablet(ctx, tablet.alias)
+			err := tablet.qsc.QueryService().Close(ctx)
+			if err != nil {
+				return err
+			}
+			err = ts.DeleteTablet(ctx, tablet.alias)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Backport https://github.com/vitessio/vitess/commit/69b49a9da4fd142a1cdd281ea080e319b05ceedb
Fixes connection leaks in vtcombo on drop/create database
