### PR TITLE
Backport v18: vtcombo: close query service on drop database

### DIFF
--- a/go/test/endtoend/vtcombo/recreate/recreate_test.go
+++ b/go/test/endtoend/vtcombo/recreate/recreate_test.go
@@ -120,8 +120,9 @@ func TestDropAndRecreateWithSameShards(t *testing.T) {
 	require.Nil(t, err)
 
 	// Assert that we're not leaking mysql connections, but allow for some wiggle room due to transient connections
-	assert.InDelta(t, mysqlConnCountBefore, mysqlConnCountAfter, 5,
-		"not within allowable delta: mysqlConnCountBefore=%d, mysqlConnCountAfter=%d", mysqlConnCountBefore, mysqlConnCountAfter)
+	delta := mysqlConnCountAfter - mysqlConnCountBefore
+	assert.LessOrEqual(t, delta, 5,
+		"mysqlConnCountBefore=%d, mysqlConnCountAfter=%d, delta=%d", mysqlConnCountBefore, mysqlConnCountAfter, delta)
 }
 
 func getMySQLConnectionCount(ctx context.Context, session *vtgateconn.VTGateSession) (int, error) {

--- a/go/test/endtoend/vtcombo/recreate/recreate_test.go
+++ b/go/test/endtoend/vtcombo/recreate/recreate_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -102,6 +103,9 @@ func TestDropAndRecreateWithSameShards(t *testing.T) {
 
 	cur := conn.Session(ks1+"@primary", nil)
 
+	mysqlConnCountBefore, err := getMySQLConnectionCount(ctx, cur)
+	require.Nil(t, err)
+
 	_, err = cur.Execute(ctx, "DROP DATABASE "+ks1, nil)
 	require.Nil(t, err)
 
@@ -109,6 +113,23 @@ func TestDropAndRecreateWithSameShards(t *testing.T) {
 	require.Nil(t, err)
 
 	assertTabletsPresent(t)
+
+	// Check the connection count after the CREATE. There will be zero connections after the DROP as the database
+	// no longer exists, but after it gets recreated any open pools will be able to reestablish connections.
+	mysqlConnCountAfter, err := getMySQLConnectionCount(ctx, cur)
+	require.Nil(t, err)
+
+	// Assert that we're not leaking mysql connections, but allow for some wiggle room due to transient connections
+	assert.InDelta(t, mysqlConnCountBefore, mysqlConnCountAfter, 5,
+		"not within allowable delta: mysqlConnCountBefore=%d, mysqlConnCountAfter=%d", mysqlConnCountBefore, mysqlConnCountAfter)
+}
+
+func getMySQLConnectionCount(ctx context.Context, session *vtgateconn.VTGateSession) (int, error) {
+	result, err := session.Execute(ctx, "select variable_value from performance_schema.global_status where variable_name='threads_connected'", nil)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(result.Rows[0][0].ToString())
 }
 
 func assertTabletsPresent(t *testing.T) {

--- a/go/vt/vtcombo/tablet_map.go
+++ b/go/vt/vtcombo/tablet_map.go
@@ -230,7 +230,11 @@ func DeleteKs(
 			tablet.tm.Stop()
 			tablet.tm.Close()
 			tablet.qsc.SchemaEngine().Close()
-			err := ts.DeleteTablet(ctx, tablet.alias)
+			err := tablet.qsc.QueryService().Close(ctx)
+			if err != nil {
+				return err
+			}
+			err = ts.DeleteTablet(ctx, tablet.alias)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Backport https://github.com/vitessio/vitess/commit/69b49a9da4fd142a1cdd281ea080e319b05ceedb
Fixes connection leaks in vtcombo on drop/create database

Also fixes the test assertion to allow a large negative delta. There are 12 fewer connections after drop/create in v18. Probably some eager connection establishment that was eliminated in v19+.

Not adding an `Available:` label as it's been added to the v19 version for future releases: https://github.com/Shopify/vitess/pull/182