### PR TITLE
Backport: Gracefully shutdown VTGate instances

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1707,7 +1707,6 @@ func (c *Conn) IsMarkedForClose() bool {
 	return c.closing
 }
 
-// GetTestConn returns a conn for testing purpose only.
-func GetTestConn() *Conn {
-	return newConn(testConn{})
+func (c *Conn) IsShuttingDown() bool {
+	return c.listener.shutdown.Load()
 }

--- a/go/mysql/conn_fake.go
+++ b/go/mysql/conn_fake.go
@@ -81,3 +81,14 @@ func (m mockAddress) String() string {
 }
 
 var _ net.Addr = (*mockAddress)(nil)
+
+// GetTestConn returns a conn for testing purpose only.
+func GetTestConn() *Conn {
+	return newConn(testConn{})
+}
+
+// GetTestServerConn is only meant to be used for testing.
+// It creates a server connection using a testConn and the provided listener.
+func GetTestServerConn(listener *Listener) *Conn {
+	return newServerConn(testConn{}, listener)
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/vitessio/vitess/commit/ad26d15b1b686e6a5946fd79b13da62c51d8d647 

This is a workaround for https://github.com/vitessio/vitess/issues/16840

This ensures that new transactions cannot be started during vtgate shutdown, which should reduce the number of transactions left open at shutdown. At that point only transactions which were started before the shutdown period would still be open, and we use a 10s shutdown period, so that should be very rare.