### PR TITLE
Fix zookeeper connection leak

### DIFF
--- a/go/vt/topo/zk2topo/zk_conn.go
+++ b/go/vt/topo/zk2topo/zk_conn.go
@@ -277,6 +277,8 @@ func (c *ZkConn) withRetry(ctx context.Context, action func(conn *zk.Conn) error
 			c.conn = nil
 		}
 		c.mu.Unlock()
+		log.Infof("zk conn: got ErrConnectionClosed: closing")
+		conn.Close()
 	}
 	return
 }
@@ -327,13 +329,9 @@ func (c *ZkConn) maybeAddAuth(ctx context.Context) {
 // clears out the connection record.
 func (c *ZkConn) handleSessionEvents(conn *zk.Conn, session <-chan zk.Event) {
 	for event := range session {
-		closeRequired := false
 
 		switch event.State {
-		case zk.StateExpired, zk.StateConnecting:
-			closeRequired = true
-			fallthrough
-		case zk.StateDisconnected:
+		case zk.StateDisconnected, zk.StateExpired, zk.StateConnecting:
 			c.mu.Lock()
 			if c.conn == conn {
 				// The ZkConn still references this
@@ -341,9 +339,8 @@ func (c *ZkConn) handleSessionEvents(conn *zk.Conn, session <-chan zk.Event) {
 				c.conn = nil
 			}
 			c.mu.Unlock()
-			if closeRequired {
-				conn.Close()
-			}
+			log.Infof("zk conn: got %v: closing", event.State)
+			conn.Close()
 			log.Infof("zk conn: session for addr %v ended: %v", c.addr, event)
 			return
 		}

--- a/go/vt/topo/zk2topo/zk_conn_test.go
+++ b/go/vt/topo/zk2topo/zk_conn_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package zk2topo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/z-division/go-zookeeper/zk"
+
+	"vitess.io/vitess/go/testfiles"
+	"vitess.io/vitess/go/vt/zkctl"
+)
+
+func TestZkConnClosedOnDisconnect(t *testing.T) {
+	zkd, serverAddr := zkctl.StartLocalZk(testfiles.GoVtTopoZk2topoZkID, testfiles.GoVtTopoZk2topoPort)
+	defer zkd.Teardown()
+
+	conn := Connect(serverAddr)
+	_, _, err := conn.Get(context.Background(), "/")
+	if err != nil {
+		t.Fatalf("Get() failed: %v", err)
+	}
+
+	if !conn.conn.State().IsConnected() {
+		t.Fatalf("Connection not connected: %v", conn.conn.State())
+	}
+
+	oldConn := conn.conn
+
+	// simulate a disconnect
+	zkd.Shutdown()
+	zkd.Start()
+
+	// do another get to trigger a new connection
+	_, _, err = conn.Get(context.Background(), "/")
+	if err != nil {
+		t.Fatalf("Get() failed: %v", err)
+	}
+
+	// Check that old connection is closed
+	_, _, err = oldConn.Get("/")
+	if err == nil {
+		t.Fatalf("Get() should have failed: %v", err)
+	}
+
+	if oldConn.State() != zk.StateDisconnected {
+		t.Fatalf("Connection not closed: %v", oldConn.State())
+	}
+}

--- a/go/vt/topo/zk2topo/zk_conn_test.go
+++ b/go/vt/topo/zk2topo/zk_conn_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/z-division/go-zookeeper/zk"
 
 	"vitess.io/vitess/go/testfiles"
@@ -31,6 +32,8 @@ func TestZkConnClosedOnDisconnect(t *testing.T) {
 	defer zkd.Teardown()
 
 	conn := Connect(serverAddr)
+	defer conn.Close()
+
 	_, _, err := conn.Get(context.Background(), "/")
 	if err != nil {
 		t.Fatalf("Get() failed: %v", err)
@@ -42,7 +45,7 @@ func TestZkConnClosedOnDisconnect(t *testing.T) {
 
 	oldConn := conn.conn
 
-	// simulate a disconnect
+	// force a disconnect
 	zkd.Shutdown()
 	zkd.Start()
 
@@ -54,11 +57,9 @@ func TestZkConnClosedOnDisconnect(t *testing.T) {
 
 	// Check that old connection is closed
 	_, _, err = oldConn.Get("/")
-	if err == nil {
-		t.Fatalf("Get() should have failed: %v", err)
-	}
+	require.ErrorContains(t, err, "zookeeper is closing")
 
 	if oldConn.State() != zk.StateDisconnected {
-		t.Fatalf("Connection not closed: %v", oldConn.State())
+		t.Fatalf("Connection is not in disconnected state: %v", oldConn.State())
 	}
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Fixes https://github.com/Shopify/vitess-project/issues/696

This PR closes the connection to the topo server whenever we get disconnected from zookeeper. This is to fix the connection/memory leak as described in the issue. It also adds additional logging whenever the connection is closed

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
