### PR TITLE
Add support for receiving mysql_server_bind_host on vttestserver

### DIFF
--- a/config/mycnf/default.cnf
+++ b/config/mycnf/default.cnf
@@ -9,6 +9,7 @@ relay-log = {{.RelayLogPath}}
 relay-log-index =  {{.RelayLogIndexPath}}
 pid-file = {{.PidFile}}
 port = {{.MysqlPort}}
+bind-address = {{.MysqlBindAddress}}
 
 {{if .SecureFilePriv}}
 secure-file-priv = {{.SecureFilePriv}}

--- a/go/cmd/mysqlctl/command/init.go
+++ b/go/cmd/mysqlctl/command/init.go
@@ -49,7 +49,7 @@ var initArgs = struct {
 
 func commandInit(cmd *cobra.Command, args []string) error {
 	// Generate my.cnf from scratch and use it to find mysqld.
-	mysqld, cnf, err := mysqlctl.CreateMysqldAndMycnf(tabletUID, mysqlSocket, mysqlPort, collationEnv)
+	mysqld, cnf, err := mysqlctl.CreateMysqldAndMycnf(tabletUID, mysqlSocket, mysqlBindAddress, mysqlPort, collationEnv)
 	if err != nil {
 		return fmt.Errorf("failed to initialize mysql config: %v", err)
 	}

--- a/go/cmd/mysqlctl/command/init_config.go
+++ b/go/cmd/mysqlctl/command/init_config.go
@@ -40,7 +40,7 @@ var InitConfig = &cobra.Command{
 
 func commandInitConfig(cmd *cobra.Command, args []string) error {
 	// Generate my.cnf from scratch and use it to find mysqld.
-	mysqld, cnf, err := mysqlctl.CreateMysqldAndMycnf(tabletUID, mysqlSocket, mysqlPort, collationEnv)
+	mysqld, cnf, err := mysqlctl.CreateMysqldAndMycnf(tabletUID, mysqlSocket, mysqlBindAddress, mysqlPort, collationEnv)
 	if err != nil {
 		return fmt.Errorf("failed to initialize mysql config: %v", err)
 	}

--- a/go/cmd/mysqlctl/command/root.go
+++ b/go/cmd/mysqlctl/command/root.go
@@ -30,10 +30,11 @@ import (
 )
 
 var (
-	mysqlPort    = 3306
-	tabletUID    = uint32(41983)
-	mysqlSocket  string
-	collationEnv *collations.Environment
+	mysqlBindAddress = "0.0.0.0"
+	mysqlPort        = 3306
+	tabletUID        = uint32(41983)
+	mysqlSocket      string
+	collationEnv     *collations.Environment
 
 	Root = &cobra.Command{
 		Use:   "mysqlctl",
@@ -70,6 +71,7 @@ func init() {
 
 	servenv.MovePersistentFlagsToCobraCommand(Root)
 
+	Root.PersistentFlags().StringVar(&mysqlBindAddress, "mysql_bind_address", mysqlBindAddress, "MySQL bind address.")
 	Root.PersistentFlags().IntVar(&mysqlPort, "mysql_port", mysqlPort, "MySQL port.")
 	Root.PersistentFlags().Uint32Var(&tabletUID, "tablet_uid", tabletUID, "Tablet UID.")
 	Root.PersistentFlags().StringVar(&mysqlSocket, "mysql_socket", mysqlSocket, "Path to the mysqld socket file.")

--- a/go/cmd/mysqlctld/cli/mysqlctld.go
+++ b/go/cmd/mysqlctld/cli/mysqlctld.go
@@ -41,10 +41,11 @@ var (
 	mysqld *mysqlctl.Mysqld
 	cnf    *mysqlctl.Mycnf
 
-	mysqlPort    = 3306
-	tabletUID    = uint32(41983)
-	mysqlSocket  string
-	collationEnv *collations.Environment
+	mysqlBindAddress = "0.0.0.0"
+	mysqlPort        = 3306
+	tabletUID        = uint32(41983)
+	mysqlSocket      string
+	collationEnv     *collations.Environment
 
 	// mysqlctl init flags
 	waitTime         = 5 * time.Minute
@@ -91,6 +92,7 @@ func init() {
 
 	servenv.MoveFlagsToCobraCommand(Main)
 
+	Main.Flags().StringVar(&mysqlBindAddress, "mysql_bind_address", mysqlBindAddress, "MySQL bind address")
 	Main.Flags().IntVar(&mysqlPort, "mysql_port", mysqlPort, "MySQL port")
 	Main.Flags().Uint32Var(&tabletUID, "tablet_uid", tabletUID, "Tablet UID")
 	Main.Flags().StringVar(&mysqlSocket, "mysql_socket", mysqlSocket, "Path to the mysqld socket file")
@@ -121,7 +123,7 @@ func run(cmd *cobra.Command, args []string) error {
 		log.Infof("mycnf file (%s) doesn't exist, initializing", mycnfFile)
 
 		var err error
-		mysqld, cnf, err = mysqlctl.CreateMysqldAndMycnf(tabletUID, mysqlSocket, mysqlPort, collationEnv)
+		mysqld, cnf, err = mysqlctl.CreateMysqldAndMycnf(tabletUID, mysqlSocket, mysqlBindAddress, mysqlPort, collationEnv)
 		if err != nil {
 			cancel()
 			return fmt.Errorf("failed to initialize mysql config: %w", err)

--- a/go/cmd/vtbackup/cli/vtbackup.go
+++ b/go/cmd/vtbackup/cli/vtbackup.go
@@ -84,6 +84,7 @@ var (
 	incrementalFromPos string
 
 	// mysqlctld-like flags
+	mysqlBindAddress     = "0.0.0.0"
 	mysqlPort            = 3306
 	mysqlSocket          string
 	mysqlTimeout         = 5 * time.Minute
@@ -331,7 +332,7 @@ func takeBackup(ctx, backgroundCtx context.Context, topoServer *topo.Server, bac
 	}()
 
 	// Start up mysqld as if we are mysqlctld provisioning a fresh tablet.
-	mysqld, mycnf, err := mysqlctl.CreateMysqldAndMycnf(tabletAlias.Uid, mysqlSocket, mysqlPort, collationEnv)
+	mysqld, mycnf, err := mysqlctl.CreateMysqldAndMycnf(tabletAlias.Uid, mysqlSocket, mysqlBindAddress, mysqlPort, collationEnv)
 	if err != nil {
 		return fmt.Errorf("failed to initialize mysql config: %v", err)
 	}

--- a/go/cmd/vtcombo/cli/main.go
+++ b/go/cmd/vtcombo/cli/main.go
@@ -75,6 +75,7 @@ In particular, it contains:
 	}
 	schemaDir             string
 	startMysql            bool
+	mysqlBindAddress      = "0.0.0.0"
 	mysqlPort             = 3306
 	externalTopoServer    bool
 	plannerName           string
@@ -145,7 +146,7 @@ func startMysqld(ctx context.Context, uid uint32) (mysqld *mysqlctl.Mysqld, cnf 
 	mycnfFile := mysqlctl.MycnfFile(uid)
 
 	if _, statErr := os.Stat(mycnfFile); os.IsNotExist(statErr) {
-		mysqld, cnf, err = mysqlctl.CreateMysqldAndMycnf(uid, "", mysqlPort, env.CollationEnv())
+		mysqld, cnf, err = mysqlctl.CreateMysqldAndMycnf(uid, "", mysqlBindAddress, mysqlPort, env.CollationEnv())
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to initialize mysql config :%w", err)
 		}

--- a/go/cmd/vttestserver/cli/main.go
+++ b/go/cmd/vttestserver/cli/main.go
@@ -183,6 +183,9 @@ func New() (cmd *cobra.Command) {
 	cmd.Flags().StringVar(&config.VtComboBindAddress, "vtcombo-bind-host", "localhost",
 		"which host to bind vtcombo servenv listener to")
 
+	cmd.Flags().StringVar(&config.MySQLServerBindAddress, "mysql-server-bind-host", "localhost",
+		"which host to bind the mysql server to")
+
 	cmd.Flags().StringVar(&mycnf, "extra_my_cnf", "",
 		"extra files to add to the config, separated by ':'")
 

--- a/go/test/endtoend/utils/mysql.go
+++ b/go/test/endtoend/utils/mysql.go
@@ -62,8 +62,8 @@ func NewMySQL(cluster *cluster.LocalProcessCluster, dbName string, schemaSQL ...
 
 // CreateMysqldAndMycnf returns a Mysqld and a Mycnf object to use for working with a MySQL
 // installation that hasn't been set up yet.
-func CreateMysqldAndMycnf(tabletUID uint32, mysqlSocket string, mysqlPort int) (*mysqlctl.Mysqld, *mysqlctl.Mycnf, error) {
-	mycnf := mysqlctl.NewMycnf(tabletUID, mysqlPort)
+func CreateMysqldAndMycnf(tabletUID uint32, mysqlSocket string, mysqlBindAddress string, mysqlPort int) (*mysqlctl.Mysqld, *mysqlctl.Mycnf, error) {
+	mycnf := mysqlctl.NewMycnf(tabletUID, mysqlBindAddress, mysqlPort)
 	if err := mycnf.RandomizeMysqlServerID(); err != nil {
 		return nil, nil, fmt.Errorf("couldn't generate random MySQL server_id: %v", err)
 	}
@@ -88,7 +88,7 @@ func NewMySQLWithMysqld(port int, hostname, dbName string, schemaSQL ...string) 
 	}
 
 	mysqlPort := port
-	mysqld, mycnf, err := CreateMysqldAndMycnf(0, "", mysqlPort)
+	mysqld, mycnf, err := CreateMysqldAndMycnf(0, "", "0.0.0.0", mysqlPort)
 	if err != nil {
 		return mysql.ConnParams{}, nil, nil, nil, err
 	}

--- a/go/vt/mysqlctl/cmd.go
+++ b/go/vt/mysqlctl/cmd.go
@@ -29,8 +29,8 @@ import (
 
 // CreateMysqldAndMycnf returns a Mysqld and a Mycnf object to use for working with a MySQL
 // installation that hasn't been set up yet.
-func CreateMysqldAndMycnf(tabletUID uint32, mysqlSocket string, mysqlPort int, collationEnv *collations.Environment) (*Mysqld, *Mycnf, error) {
-	mycnf := NewMycnf(tabletUID, mysqlPort)
+func CreateMysqldAndMycnf(tabletUID uint32, mysqlSocket string, mysqlBindAddress string, mysqlPort int, collationEnv *collations.Environment) (*Mysqld, *Mycnf, error) {
+	mycnf := NewMycnf(tabletUID, mysqlBindAddress, mysqlPort)
 	// Choose a random MySQL server-id, since this is a fresh data dir.
 	// We don't want to use the tablet UID as the MySQL server-id,
 	// because reusing server-ids is not safe.
@@ -56,7 +56,7 @@ func CreateMysqldAndMycnf(tabletUID uint32, mysqlSocket string, mysqlPort int, c
 // of the MySQL instance.
 func OpenMysqldAndMycnf(tabletUID uint32, collationEnv *collations.Environment) (*Mysqld, *Mycnf, error) {
 	// We pass a port of 0, this will be read and overwritten from the path on disk
-	mycnf, err := ReadMycnf(NewMycnf(tabletUID, 0), 0)
+	mycnf, err := ReadMycnf(NewMycnf(tabletUID, "0.0.0.0", 0), 0)
 	if err != nil {
 		return nil, nil, fmt.Errorf("couldn't read my.cnf file: %v", err)
 	}

--- a/go/vt/mysqlctl/mycnf.go
+++ b/go/vt/mysqlctl/mycnf.go
@@ -42,6 +42,10 @@ type Mycnf struct {
 	// Used to create a bunch of named directories.
 	ServerID uint32
 
+	// MysqlBindAddress is the host for the MySQL server running on this machine.
+	// It is mainly used to communicate with topology server.
+	MysqlBindAddress string
+
 	// MysqlPort is the port for the MySQL server running on this machine.
 	// It is mainly used to communicate with topology server.
 	MysqlPort int
@@ -218,6 +222,7 @@ func ReadMycnf(mycnf *Mycnf, waitTime time.Duration) (*Mycnf, error) {
 	mycnf.MysqlPort = port
 
 	mapping := map[string]*string{
+		"bind-address":              &mycnf.MysqlBindAddress,
 		"datadir":                   &mycnf.DataDir,
 		"innodb_data_home_dir":      &mycnf.InnodbDataHomeDir,
 		"innodb_log_group_home_dir": &mycnf.InnodbLogGroupHomeDir,

--- a/go/vt/mysqlctl/mycnf_flag.go
+++ b/go/vt/mysqlctl/mycnf_flag.go
@@ -32,6 +32,7 @@ import (
 var (
 	// the individual command line parameters
 	flagServerID              int
+	flagMysqlBindAddress      string
 	flagMysqlPort             int
 	flagDataDir               string
 	flagInnodbDataHomeDir     string
@@ -63,6 +64,7 @@ const (
 func RegisterFlags() {
 	servenv.OnParse(func(fs *pflag.FlagSet) {
 		fs.IntVar(&flagServerID, "mycnf_server_id", flagServerID, "mysql server id of the server (if specified, mycnf-file will be ignored)")
+		fs.StringVar(&flagMysqlBindAddress, "mycnf_mysql_bin_address", flagMysqlBindAddress, "address mysql binds on")
 		fs.IntVar(&flagMysqlPort, "mycnf_mysql_port", flagMysqlPort, "port mysql is listening on")
 		fs.StringVar(&flagDataDir, "mycnf_data_dir", flagDataDir, "data directory for mysql")
 		fs.StringVar(&flagInnodbDataHomeDir, "mycnf_innodb_data_home_dir", flagInnodbDataHomeDir, "Innodb data home directory")
@@ -103,6 +105,7 @@ func NewMycnfFromFlags(uid uint32) (mycnf *Mycnf, err error) {
 		log.Info("mycnf_server_id is specified, using command line parameters for mysql config")
 		return &Mycnf{
 			ServerID:              uint32(flagServerID),
+			MysqlBindAddress:      flagMysqlBindAddress,
 			MysqlPort:             flagMysqlPort,
 			DataDir:               flagDataDir,
 			InnodbDataHomeDir:     flagInnodbDataHomeDir,
@@ -133,7 +136,7 @@ func NewMycnfFromFlags(uid uint32) (mycnf *Mycnf, err error) {
 	} else {
 		log.Infof("No mycnf_server_id specified, using mycnf-file file %v", flagMycnfFile)
 	}
-	mycnf = NewMycnf(uid, 0)
+	mycnf = NewMycnf(uid, "0.0.0.0", 0)
 	mycnf.Path = flagMycnfFile
 	return ReadMycnf(mycnf, waitForMyCnf)
 }

--- a/go/vt/mysqlctl/mycnf_gen.go
+++ b/go/vt/mysqlctl/mycnf_gen.go
@@ -71,11 +71,12 @@ func registerMyCnfFlags(fs *pflag.FlagSet) {
 // uid is a unique id for a particular tablet - it must be unique within the
 // tabletservers deployed within a keyspace, lest there be collisions on disk.
 // mysqldPort needs to be unique per instance per machine.
-func NewMycnf(tabletUID uint32, mysqlPort int) *Mycnf {
+func NewMycnf(tabletUID uint32, mysqlBindAddress string, mysqlPort int) *Mycnf {
 	cnf := new(Mycnf)
 	cnf.Path = MycnfFile(tabletUID)
 	tabletDir := TabletDir(tabletUID)
 	cnf.ServerID = tabletUID
+	cnf.MysqlBindAddress = mysqlBindAddress
 	cnf.MysqlPort = mysqlPort
 	cnf.DataDir = path.Join(tabletDir, dataDir)
 	cnf.InnodbDataHomeDir = path.Join(tabletDir, innodbDataSubdir)

--- a/go/vt/mysqlctl/mycnf_test.go
+++ b/go/vt/mysqlctl/mycnf_test.go
@@ -39,7 +39,7 @@ func TestMycnf(t *testing.T) {
 	os.Remove(MycnfPath)
 
 	uid := uint32(11111)
-	cnf := NewMycnf(uid, 6802)
+	cnf := NewMycnf(uid, "0.0.0.0", 6802)
 	myTemplateSource := new(bytes.Buffer)
 	myTemplateSource.WriteString("[mysqld]\n")
 	// Assigning ServerID to be different from tablet UID to make sure that there are no
@@ -52,7 +52,7 @@ func TestMycnf(t *testing.T) {
 	t.Logf("data: %v", data)
 
 	// Since there is no my.cnf file, reading it should fail with a no such file error.
-	mycnf := NewMycnf(uid, 0)
+	mycnf := NewMycnf(uid, "0.0.0.0", 0)
 	mycnf.Path = MycnfPath
 	_, err = ReadMycnf(mycnf, 0)
 	require.ErrorContains(t, err, "no such file or directory")
@@ -100,7 +100,7 @@ func TestMycnf(t *testing.T) {
 // nolint
 func NoTestMycnfHook(t *testing.T) {
 	uid := uint32(11111)
-	cnf := NewMycnf(uid, 6802)
+	cnf := NewMycnf(uid, "0.0.0.0", 6802)
 	// Assigning ServerID to be different from tablet UID to make sure that there are no
 	// assumptions in the code that those IDs are the same.
 	cnf.ServerID = 22222
@@ -125,7 +125,7 @@ func NoTestMycnfHook(t *testing.T) {
 	_, err = os.ReadFile(cnf.Path)
 	require.NoError(t, err)
 
-	mycnf := NewMycnf(uid, 0)
+	mycnf := NewMycnf(uid, "0.0.0.0", 0)
 	mycnf.Path = cnf.Path
 	mycnf, err = ReadMycnf(mycnf, 0)
 	if err != nil {

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -135,7 +135,7 @@ func (vte *VTExplain) newTablet(ctx context.Context, env *vtenv.Environment, opt
 	params := db.ConnParams()
 	cp := *params
 	dbcfgs := dbconfigs.NewTestDBConfigs(cp, cp, "")
-	cnf := mysqlctl.NewMycnf(22222, 6802)
+	cnf := mysqlctl.NewMycnf(22222, "0.0.0.0", 6802)
 	cnf.ServerID = 33333
 
 	target := querypb.Target{

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -117,6 +117,11 @@ type Config struct {
 	// MySQL protocol bind address.
 	// vtcombo will bind to this address when exposing the mysql protocol socket
 	MySQLBindHost string
+
+	// MySQL server bind address.
+	// mysqlctl/mysqld will bind to this address when exposing the mysql protocol socket
+	MySQLServerBindAddress string
+
 	// SnapshotFile is the path to the MySQL Snapshot that will be used to
 	// initialize the mysqld instance in the cluster. Note that some environments
 	// do not suppport initialization through snapshot files.
@@ -294,9 +299,9 @@ func (db *LocalCluster) MySQLConnParams() mysql.ConnParams {
 
 func (db *LocalCluster) MySQLTCPConnParams() mysql.ConnParams {
 	connParams := db.mysql.Params(db.DbName())
-	_, port := db.mysql.Address()
+	host, port := db.mysql.Address()
 	connParams.UnixSocket = ""
-	connParams.Host = "127.0.0.1"
+	connParams.Host = host
 	connParams.Port = port
 	return connParams
 }
@@ -387,6 +392,10 @@ func (db *LocalCluster) Setup() error {
 	initializing := true
 	if db.PersistentMode && dirExist(db.mysql.TabletDir()) {
 		initializing = false
+	}
+
+	if db.Config.MySQLServerBindAddress != "" {
+		db.mysql.SetHost(db.Config.MySQLServerBindAddress)
 	}
 
 	if initializing {
@@ -663,6 +672,7 @@ func (db *LocalCluster) JSONConfig() any {
 		"grpc_bind_address":  db.vt.BindAddressGprc,
 		"socket":             db.mysql.UnixSocket(),
 		"vtcombo_mysql_port": db.Env.PortForProtocol("vtcombo_mysql_port", ""),
+		"mysql_bind_address": db.vt.BindAddressMysql,
 		"mysql":              db.Env.PortForProtocol("mysql", ""),
 	}
 

--- a/go/vt/vttest/toxiproxyctl.go
+++ b/go/vt/vttest/toxiproxyctl.go
@@ -183,6 +183,9 @@ func (ctl *Toxiproxyctl) Address() (string, int) {
 	return "", ctl.port
 }
 
+// SetHost allows to confgireu the host as needed
+func (ctl *Toxiproxyctl) SetHost(host string) {}
+
 // UnixSocket returns the path to the local Unix socket required to connect to mysqld.
 func (ctl *Toxiproxyctl) UnixSocket() string {
 	// Toxiproxy does not support Unix sockets

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -44,17 +44,18 @@ type HealthChecker func(addr string) bool
 // It can be spawned manually or through one of the available
 // helper methods.
 type VtProcess struct {
-	Name            string
-	Directory       string
-	LogDirectory    string
-	Binary          string
-	ExtraArgs       []string
-	Env             []string
-	BindAddress     string
-	BindAddressGprc string
-	Port            int
-	PortGrpc        int
-	HealthCheck     HealthChecker
+	Name             string
+	Directory        string
+	LogDirectory     string
+	Binary           string
+	ExtraArgs        []string
+	Env              []string
+	BindAddress      string
+	BindAddressGprc  string
+	BindAddressMysql string
+	Port             int
+	PortGrpc         int
+	HealthCheck      HealthChecker
 
 	proc *exec.Cmd
 	exit chan error
@@ -209,18 +210,23 @@ func VtcomboProcess(environment Environment, args *Config, mysql MySQLManager) (
 	if servenv.GRPCBindAddress() != "" {
 		grpcBindAddress = servenv.GRPCBindAddress()
 	}
+	mysqlAddress := "127.0.0.1"
+	if args.MySQLServerBindAddress != "" {
+		mysqlAddress = args.MySQLServerBindAddress
+	}
 
 	vt := &VtProcess{
-		Name:            "vtcombo",
-		Directory:       environment.Directory(),
-		LogDirectory:    environment.LogDirectory(),
-		Binary:          environment.BinaryPath("vtcombo"),
-		BindAddress:     vtcomboBindAddress,
-		BindAddressGprc: grpcBindAddress,
-		Port:            environment.PortForProtocol("vtcombo", ""),
-		PortGrpc:        environment.PortForProtocol("vtcombo", "grpc"),
-		HealthCheck:     environment.ProcessHealthCheck("vtcombo"),
-		Env:             environment.EnvVars(),
+		Name:             "vtcombo",
+		Directory:        environment.Directory(),
+		LogDirectory:     environment.LogDirectory(),
+		Binary:           environment.BinaryPath("vtcombo"),
+		BindAddress:      vtcomboBindAddress,
+		BindAddressGprc:  grpcBindAddress,
+		BindAddressMysql: mysqlAddress,
+		Port:             environment.PortForProtocol("vtcombo", ""),
+		PortGrpc:         environment.PortForProtocol("vtcombo", "grpc"),
+		HealthCheck:      environment.ProcessHealthCheck("vtcombo"),
+		Env:              environment.EnvVars(),
 	}
 
 	user, pass := mysql.Auth()


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

When  `--mysql-server-bind-host` is supplied to `vttestserver`, it is now forwarded up to `mysqlctl` and `mysqlctld`, and then finally added to `my.cnf` file. MySQL then respects the expected IP we want it to bind on.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Part of https://github.com/vitessio/vitess/issues/16798

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
