### PR TITLE
mysqlctl: ship mysql84.cnf for MySQL/Percona 8.4 on v18

### DIFF
--- a/config/embed.go
+++ b/config/embed.go
@@ -16,3 +16,6 @@ var MycnfMySQL57 string
 
 //go:embed mycnf/mysql80.cnf
 var MycnfMySQL80 string
+
+//go:embed mycnf/mysql84.cnf
+var MycnfMySQL84 string

--- a/config/mycnf/mysql84.cnf
+++ b/config/mycnf/mysql84.cnf
@@ -1,0 +1,43 @@
+# This file is auto-included when MySQL 8.4.0 or later is detected.
+
+# all db instances should skip starting replication threads - that way we can do any
+# additional configuration (like enabling semi-sync) before we connect to
+# the source.
+skip_replica_start
+
+# MySQL 8.0 enables binlog by default with sync_binlog and TABLE info repositories
+# It does not enable GTIDs or enforced GTID consistency
+
+gtid_mode = ON
+enforce_gtid_consistency
+relay_log_recovery = 1
+binlog_expire_logs_seconds = 259200
+
+# disable mysqlx
+mysqlx = 0
+
+# 8.4 disables mysql_native_password by default, but we keep it
+# enabled for compatibility while upgrading Vitess and / or MySQL.
+mysql_native_password = ON
+
+# Semi-sync replication is required for automated unplanned failover
+# (when the primary goes away). Here we just load the plugin so it's
+# available if desired, but it's disabled at startup.
+#
+# VTTablet will enable semi-sync at the proper time when replication is set up,
+# or when a primary is promoted or demoted based on the durability policy configured.
+plugin-load = rpl_semi_sync_source=semisync_source.so;rpl_semi_sync_replica=semisync_replica.so
+
+# MySQL 8.0.26 and later will not load plugins during --initialize
+# which makes these options unknown. Prefixing with --loose
+# tells the server it's fine if they are not understood.
+loose_rpl_semi_sync_source_timeout = 1000000000000000000
+loose_rpl_semi_sync_source_wait_no_replica = 1
+
+# In order to protect against any errand GTIDs we will start the mysql instance
+# in super-read-only mode.
+super-read-only
+
+# Replication parameters to ensure reparents are fast.
+replica_net_timeout = 8
+

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -820,7 +820,11 @@ func (mysqld *Mysqld) getMycnfTemplate() string {
 				log.Infof("this version of Vitess does not include built-in support for %v %v", mysqld.capabilities.flavor, mysqld.capabilities.version)
 			}
 		case 8:
-			versionConfig = config.MycnfMySQL80
+			if mysqld.capabilities.version.Minor >= 4 {
+				versionConfig = config.MycnfMySQL84
+			} else {
+				versionConfig = config.MycnfMySQL80
+			}
 		default:
 			log.Infof("this version of Vitess does not include built-in support for %v %v", mysqld.capabilities.flavor, mysqld.capabilities.version)
 		}


### PR DESCRIPTION
## Problem

Shopify's dev environment (`shop/world` Tectonix) recently bumped the dev MySQL package to **Percona 8.4** ([shop/world#700506](https://github.com/shop/world/pull/700506)) to match production. But vitess **v18** only embeds `config/mycnf/mysql80.cnf`, which still sets:

- `default_authentication_plugin = mysql_native_password` — **removed in MySQL 8.4**
- `plugin-load = rpl_semi_sync_master=...;rpl_semi_sync_slave=...` — plugins **renamed** to `_source`/`_replica` in 8.4

`vttestserver`/`mysqlctl` therefore aborts at init:

```
[ERROR] [MY-000067] [Server] unknown variable 'default_authentication_plugin=mysql_native_password'.
Error: failed init mysql: .../mysqld: exit status 1
```

This breaks `dev up` for every shop-server developer running Percona 8.4 locally.

## Fix

`getMycnfTemplate()` already selects the flavor cnf by detected version, and **`main` already has an 8.4-correct `mysql84.cnf`** (uses `mysql_native_password = ON`, the renamed semisync plugins, `skip_replica_start`, etc.). This backports that machinery to **v18** with no behavior change for 8.0:

- add `config/mycnf/mysql84.cnf` (copied from `main`)
- embed it in `config/embed.go`
- route detected MySQL/Percona **`Minor >= 4`** → `config.MycnfMySQL84` in `go/vt/mysqlctl/mysqld.go`

Once a `v18.0.5-shopify-4` release is cut and `vitess-build` publishes the tarball, vitess auto-selects `mysql84.cnf` for Percona 8.4 — no `EXTRA_MY_CNF` or template hacks needed.

## Notes

- Draft: I don't build vitess locally, so this needs a maintainer to compile/test and decide whether the same backport should land on the **v19** shopify line.
- The 19.x and `main` branches already carry this; only the v18 release line was missing it.